### PR TITLE
Add HOF pareto front function and cross validation

### DIFF
--- a/titanic-example.ipynb
+++ b/titanic-example.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 155,
    "metadata": {},
    "outputs": [
     {
@@ -11,15 +11,6 @@
      "text": [
       "%pylab is deprecated, use %matplotlib inline and import the required libraries.\n",
       "Populating the interactive namespace from numpy and matplotlib\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/tristanpeat/miniforge3/envs/tensorflow/lib/python3.10/site-packages/IPython/core/magics/pylab.py:162: UserWarning: pylab import has clobbered these variables: ['logistic']\n",
-      "`%matplotlib` prevents importing * from pylab and numpy\n",
-      "  warn(\"pylab import has clobbered these variables: %s\"  % clobbered +\n"
      ]
     }
    ],
@@ -31,7 +22,7 @@
     "import numpy as np\n",
     "# Sklearn provides various modules with a common API\n",
     "from sklearn import svm, tree, neighbors, neural_network, linear_model, ensemble\n",
-    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.model_selection import train_test_split, KFold, StratifiedKFold\n",
     "from sklearn.metrics import confusion_matrix\n",
     "\n",
     "from sklearn.preprocessing import LabelEncoder\n",
@@ -52,7 +43,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 156,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -63,7 +54,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 157,
    "metadata": {},
    "outputs": [
     {
@@ -215,7 +206,7 @@
        "5                0      0            373450   8.0500   NaN        S  "
       ]
      },
-     "execution_count": 25,
+     "execution_count": 157,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -228,7 +219,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 158,
    "metadata": {},
    "outputs": [
     {
@@ -365,7 +356,7 @@
        "896          22.0      1      1  3101298  12.2875   NaN        S  "
       ]
      },
-     "execution_count": 26,
+     "execution_count": 158,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -376,7 +367,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 159,
    "metadata": {},
    "outputs": [
     {
@@ -385,7 +376,7 @@
        "['Age', 'Cabin', 'Embarked']"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 159,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -396,7 +387,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 160,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -425,15 +416,8 @@
     "#     df['WomanOrBoySurvived'] = df.FamilySurvivedCount / df.WomanOrBoyCount.replace(0, np.nan)\n",
     "#     df.WomanOrBoyCount = df.WomanOrBoyCount.replace(np.nan, 0)\n",
     "#     df['Alone'] = (df.WomanOrBoyCount == 0)\n",
-    "    return df"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 29,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "    return df\n",
+    "\n",
     "def fill_missing(df):\n",
     "    # Embarked\n",
     "    df['Embarked'] = df['Embarked'].fillna('S')\n",
@@ -449,12 +433,12 @@
     "    df['Age'] = df.groupby(['Sex', 'Pclass', 'Title'])['Age'].apply(lambda x: x.fillna(x.median()))\n",
     "    # Family_Size\n",
     "    df['Family_Size'] = df['SibSp'] + df['Parch'] + 1\n",
-    "    return df"
+    "    return df    "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 161,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -477,7 +461,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 162,
    "metadata": {},
    "outputs": [
     {
@@ -525,8 +509,7 @@
     }
    ],
    "source": [
-    "# don't drop name, ticket, cabin\n",
-    "# train_data.drop(columns=['Name', 'Ticket', 'Cabin'], inplace=True)\n",
+    "RANDOM_SEED = 10\n",
     "\n",
     "# combine train and test into single df for preprocessing --> becareful bc test won't have survived column\n",
     "df = pd.concat([train_data, test_data], axis=0, sort=False)\n",
@@ -560,7 +543,7 @@
     "y_train = train_data.loc[:, 'Survived']\n",
     "\n",
     "# try kfold from scikit-learn\n",
-    "X_train, X_test, y_train, y_test = train_test_split(X_train, y_train, test_size=0.33, random_state=10)\n",
+    "X_train, X_test, y_train, y_test = train_test_split(X_train, y_train, test_size=0.33, random_state=RANDOM_SEED)\n",
     "\n",
     "print(X_train.head())\n",
     "print(y_train.head())\n",
@@ -569,7 +552,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 163,
    "metadata": {},
    "outputs": [
     {
@@ -635,7 +618,7 @@
        "Index: []"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 163,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -662,14 +645,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 164,
    "metadata": {},
    "outputs": [],
    "source": [
+    "'''\n",
+    "Use this method to score the cross evaluation\n",
+    "This way we will have the confusion matrix values for each fold and we can easily get the average fnr and fpr\n",
+    "'''\n",
+    "def confusion_matrix_scorer(clf, X, y):\n",
+    "    y_pred = clf.predict(X)\n",
+    "    cm = confusion_matrix(y, y_pred)\n",
+    "    return {'tn': cm[0, 0], 'fp': cm[0, 1],\n",
+    "            'fn': cm[1, 0], 'tp': cm[1, 1]}\n",
+    "\n",
+    "# cv_results = cross_validate(svm, X, y, cv=5,\n",
+    "#                             scoring=confusion_matrix_scorer)\n",
+    "\n",
     "# fit and evaluate model\n",
     "y_truth = y_test.values\n",
     "def eval(model):\n",
+    "    # cross validation --> generate different train test splits\n",
+    "    \n",
+    "    kf = StratifiedKFold(n_splits=5, shuffle=True, random_state=42)\n",
+    "\n",
+    "    cnt = 1\n",
+    "    # split()  method generate indices to split data into training and test set.\n",
+    "    for train_index, test_index in kf.split(X_train.values, y_train.values):\n",
+    "        print(f'Fold:{cnt}, Train set: {len(train_index)}, Test set:{len(test_index)}')\n",
+    "        cnt+=1\n",
+    "\n",
     "    model.fit(X_train.values, y_train.values)\n",
+    "\n",
+    "    # cross eval accuracy\n",
+    "    score = cross_val_score(model, X_train.values, y_train.values, cv = kf, scoring=\"accuracy\")\n",
+    "    print(f'Scores for each fold are: {score}')\n",
+    "    print(\"Average Score of CVs: \", sum(score)/len(score))\n",
+    "\n",
+    "    # normal accuracy\n",
     "    print(\"Accuracy:\", model.score(X_test.values, y_test.values))\n",
     "    y_pred = model.predict(X_test.values)\n",
     "    tn, fp, fn, tp = confusion_matrix(y_truth, y_pred).ravel()\n",
@@ -687,12 +700,12 @@
     "    fnr = fn / (fn + tp)\n",
     "    print(\"FNR\", fnr)\n",
     "    models[type(model).__name__] = (fpr, fnr)\n",
-    "    print(models)"
+    "    # print(models)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 165,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -700,28 +713,41 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Tree"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 166,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Accuracy: 0.7728813559322034\n",
+      "Fold:1, Train set: 476, Test set:120\n",
+      "Fold:2, Train set: 477, Test set:119\n",
+      "Fold:3, Train set: 477, Test set:119\n",
+      "Fold:4, Train set: 477, Test set:119\n",
+      "Fold:5, Train set: 477, Test set:119\n",
+      "Scores for each fold are: [0.76666667 0.74789916 0.76470588 0.76470588 0.69747899]\n",
+      "Average Score of CVs:  0.7482913165266106\n",
+      "Accuracy: 0.7830508474576271\n",
       "\n",
       "Confusion Matrix\n",
-      "[[149  42]\n",
+      "[[152  39]\n",
       " [ 25  79]]\n",
       "\n",
-      "True Negatives 149\n",
-      "False Positives 42\n",
+      "True Negatives 152\n",
+      "False Positives 39\n",
       "False Negatives 25\n",
       "True Positives 79\n",
       "\n",
-      "FPR 0.2198952879581152\n",
-      "FNR 0.2403846153846154\n",
-      "{'DecisionTreeClassifier': (0.2198952879581152, 0.2403846153846154)}\n"
+      "FPR 0.20418848167539266\n",
+      "FNR 0.2403846153846154\n"
      ]
     }
    ],
@@ -731,14 +757,28 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## KNN"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 167,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Fold:1, Train set: 476, Test set:120\n",
+      "Fold:2, Train set: 477, Test set:119\n",
+      "Fold:3, Train set: 477, Test set:119\n",
+      "Fold:4, Train set: 477, Test set:119\n",
+      "Fold:5, Train set: 477, Test set:119\n",
+      "Scores for each fold are: [0.65       0.64705882 0.71428571 0.65546218 0.64705882]\n",
+      "Average Score of CVs:  0.6627731092436975\n",
       "Accuracy: 0.6745762711864407\n",
       "\n",
       "Confusion Matrix\n",
@@ -751,8 +791,7 @@
       "True Positives 44\n",
       "\n",
       "FPR 0.18848167539267016\n",
-      "FNR 0.5769230769230769\n",
-      "{'DecisionTreeClassifier': (0.2198952879581152, 0.2403846153846154), 'KNeighborsClassifier': (0.18848167539267016, 0.5769230769230769)}\n"
+      "FNR 0.5769230769230769\n"
      ]
     }
    ],
@@ -762,28 +801,41 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## NN"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 168,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Accuracy: 0.8033898305084746\n",
+      "Fold:1, Train set: 476, Test set:120\n",
+      "Fold:2, Train set: 477, Test set:119\n",
+      "Fold:3, Train set: 477, Test set:119\n",
+      "Fold:4, Train set: 477, Test set:119\n",
+      "Fold:5, Train set: 477, Test set:119\n",
+      "Scores for each fold are: [0.85833333 0.74789916 0.82352941 0.68907563 0.75630252]\n",
+      "Average Score of CVs:  0.7750280112044818\n",
+      "Accuracy: 0.7830508474576271\n",
       "\n",
       "Confusion Matrix\n",
-      "[[167  24]\n",
-      " [ 34  70]]\n",
+      "[[173  18]\n",
+      " [ 46  58]]\n",
       "\n",
-      "True Negatives 167\n",
-      "False Positives 24\n",
-      "False Negatives 34\n",
-      "True Positives 70\n",
+      "True Negatives 173\n",
+      "False Positives 18\n",
+      "False Negatives 46\n",
+      "True Positives 58\n",
       "\n",
-      "FPR 0.1256544502617801\n",
-      "FNR 0.3269230769230769\n",
-      "{'DecisionTreeClassifier': (0.2198952879581152, 0.2403846153846154), 'KNeighborsClassifier': (0.18848167539267016, 0.5769230769230769), 'MLPClassifier': (0.1256544502617801, 0.3269230769230769)}\n"
+      "FPR 0.09424083769633508\n",
+      "FNR 0.4423076923076923\n"
      ]
     }
    ],
@@ -801,13 +853,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 169,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Fold:1, Train set: 476, Test set:120\n",
+      "Fold:2, Train set: 477, Test set:119\n",
+      "Fold:3, Train set: 477, Test set:119\n",
+      "Fold:4, Train set: 477, Test set:119\n",
+      "Fold:5, Train set: 477, Test set:119\n",
+      "Scores for each fold are: [0.89166667 0.78991597 0.81512605 0.79831933 0.82352941]\n",
+      "Average Score of CVs:  0.8237114845938376\n",
       "Accuracy: 0.8338983050847457\n",
       "\n",
       "Confusion Matrix\n",
@@ -820,8 +879,7 @@
       "True Positives 78\n",
       "\n",
       "FPR 0.12041884816753927\n",
-      "FNR 0.25\n",
-      "{'DecisionTreeClassifier': (0.2198952879581152, 0.2403846153846154), 'KNeighborsClassifier': (0.18848167539267016, 0.5769230769230769), 'MLPClassifier': (0.1256544502617801, 0.3269230769230769), 'SVC': (0.12041884816753927, 0.25)}\n"
+      "FNR 0.25\n"
      ]
     }
    ],
@@ -832,33 +890,49 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 170,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Accuracy: 0.7322033898305085\n",
+      "Fold:1, Train set: 476, Test set:120\n",
+      "Fold:2, Train set: 477, Test set:119\n",
+      "Fold:3, Train set: 477, Test set:119\n",
+      "Fold:4, Train set: 477, Test set:119\n",
+      "Fold:5, Train set: 477, Test set:119\n",
+      "Scores for each fold are: [0.575      0.7394958  0.66386555 0.75630252 0.59663866]\n",
+      "Average Score of CVs:  0.6662605042016807\n",
+      "Accuracy: 0.8\n",
       "\n",
       "Confusion Matrix\n",
-      "[[182   9]\n",
-      " [ 70  34]]\n",
+      "[[173  18]\n",
+      " [ 41  63]]\n",
       "\n",
-      "True Negatives 182\n",
-      "False Positives 9\n",
-      "False Negatives 70\n",
-      "True Positives 34\n",
+      "True Negatives 173\n",
+      "False Positives 18\n",
+      "False Negatives 41\n",
+      "True Positives 63\n",
       "\n",
-      "FPR 0.04712041884816754\n",
-      "FNR 0.6730769230769231\n",
-      "{'DecisionTreeClassifier': (0.2198952879581152, 0.2403846153846154), 'KNeighborsClassifier': (0.18848167539267016, 0.5769230769230769), 'MLPClassifier': (0.1256544502617801, 0.3269230769230769), 'SVC': (0.12041884816753927, 0.25), 'LinearSVC': (0.04712041884816754, 0.6730769230769231)}\n"
+      "FPR 0.09424083769633508\n",
+      "FNR 0.3942307692307692\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/Users/tristanpeat/miniforge3/envs/tensorflow/lib/python3.10/site-packages/sklearn/svm/_base.py:1225: ConvergenceWarning: Liblinear failed to converge, increase the number of iterations.\n",
+      "  warnings.warn(\n",
+      "/Users/tristanpeat/miniforge3/envs/tensorflow/lib/python3.10/site-packages/sklearn/svm/_base.py:1225: ConvergenceWarning: Liblinear failed to converge, increase the number of iterations.\n",
+      "  warnings.warn(\n",
+      "/Users/tristanpeat/miniforge3/envs/tensorflow/lib/python3.10/site-packages/sklearn/svm/_base.py:1225: ConvergenceWarning: Liblinear failed to converge, increase the number of iterations.\n",
+      "  warnings.warn(\n",
+      "/Users/tristanpeat/miniforge3/envs/tensorflow/lib/python3.10/site-packages/sklearn/svm/_base.py:1225: ConvergenceWarning: Liblinear failed to converge, increase the number of iterations.\n",
+      "  warnings.warn(\n",
+      "/Users/tristanpeat/miniforge3/envs/tensorflow/lib/python3.10/site-packages/sklearn/svm/_base.py:1225: ConvergenceWarning: Liblinear failed to converge, increase the number of iterations.\n",
+      "  warnings.warn(\n",
       "/Users/tristanpeat/miniforge3/envs/tensorflow/lib/python3.10/site-packages/sklearn/svm/_base.py:1225: ConvergenceWarning: Liblinear failed to converge, increase the number of iterations.\n",
       "  warnings.warn(\n"
      ]
@@ -870,14 +944,28 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Linear"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 171,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Fold:1, Train set: 476, Test set:120\n",
+      "Fold:2, Train set: 477, Test set:119\n",
+      "Fold:3, Train set: 477, Test set:119\n",
+      "Fold:4, Train set: 477, Test set:119\n",
+      "Fold:5, Train set: 477, Test set:119\n",
+      "Scores for each fold are: [0.85833333 0.78151261 0.81512605 0.78991597 0.78151261]\n",
+      "Average Score of CVs:  0.8052801120448179\n",
       "Accuracy: 0.8203389830508474\n",
       "\n",
       "Confusion Matrix\n",
@@ -890,14 +978,53 @@
       "True Positives 74\n",
       "\n",
       "FPR 0.12041884816753927\n",
-      "FNR 0.28846153846153844\n",
-      "{'DecisionTreeClassifier': (0.2198952879581152, 0.2403846153846154), 'KNeighborsClassifier': (0.18848167539267016, 0.5769230769230769), 'MLPClassifier': (0.1256544502617801, 0.3269230769230769), 'SVC': (0.12041884816753927, 0.25), 'LinearSVC': (0.04712041884816754, 0.6730769230769231), 'LogisticRegression': (0.12041884816753927, 0.28846153846153844)}\n"
+      "FNR 0.28846153846153844\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/Users/tristanpeat/miniforge3/envs/tensorflow/lib/python3.10/site-packages/sklearn/linear_model/_logistic.py:444: ConvergenceWarning: lbfgs failed to converge (status=1):\n",
+      "STOP: TOTAL NO. of ITERATIONS REACHED LIMIT.\n",
+      "\n",
+      "Increase the number of iterations (max_iter) or scale the data as shown in:\n",
+      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
+      "Please also refer to the documentation for alternative solver options:\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
+      "  n_iter_i = _check_optimize_result(\n",
+      "/Users/tristanpeat/miniforge3/envs/tensorflow/lib/python3.10/site-packages/sklearn/linear_model/_logistic.py:444: ConvergenceWarning: lbfgs failed to converge (status=1):\n",
+      "STOP: TOTAL NO. of ITERATIONS REACHED LIMIT.\n",
+      "\n",
+      "Increase the number of iterations (max_iter) or scale the data as shown in:\n",
+      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
+      "Please also refer to the documentation for alternative solver options:\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
+      "  n_iter_i = _check_optimize_result(\n",
+      "/Users/tristanpeat/miniforge3/envs/tensorflow/lib/python3.10/site-packages/sklearn/linear_model/_logistic.py:444: ConvergenceWarning: lbfgs failed to converge (status=1):\n",
+      "STOP: TOTAL NO. of ITERATIONS REACHED LIMIT.\n",
+      "\n",
+      "Increase the number of iterations (max_iter) or scale the data as shown in:\n",
+      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
+      "Please also refer to the documentation for alternative solver options:\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
+      "  n_iter_i = _check_optimize_result(\n",
+      "/Users/tristanpeat/miniforge3/envs/tensorflow/lib/python3.10/site-packages/sklearn/linear_model/_logistic.py:444: ConvergenceWarning: lbfgs failed to converge (status=1):\n",
+      "STOP: TOTAL NO. of ITERATIONS REACHED LIMIT.\n",
+      "\n",
+      "Increase the number of iterations (max_iter) or scale the data as shown in:\n",
+      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
+      "Please also refer to the documentation for alternative solver options:\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
+      "  n_iter_i = _check_optimize_result(\n",
+      "/Users/tristanpeat/miniforge3/envs/tensorflow/lib/python3.10/site-packages/sklearn/linear_model/_logistic.py:444: ConvergenceWarning: lbfgs failed to converge (status=1):\n",
+      "STOP: TOTAL NO. of ITERATIONS REACHED LIMIT.\n",
+      "\n",
+      "Increase the number of iterations (max_iter) or scale the data as shown in:\n",
+      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
+      "Please also refer to the documentation for alternative solver options:\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
+      "  n_iter_i = _check_optimize_result(\n",
       "/Users/tristanpeat/miniforge3/envs/tensorflow/lib/python3.10/site-packages/sklearn/linear_model/_logistic.py:444: ConvergenceWarning: lbfgs failed to converge (status=1):\n",
       "STOP: TOTAL NO. of ITERATIONS REACHED LIMIT.\n",
       "\n",
@@ -916,13 +1043,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 172,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Fold:1, Train set: 476, Test set:120\n",
+      "Fold:2, Train set: 477, Test set:119\n",
+      "Fold:3, Train set: 477, Test set:119\n",
+      "Fold:4, Train set: 477, Test set:119\n",
+      "Fold:5, Train set: 477, Test set:119\n",
+      "Scores for each fold are: [0.61666667 0.6302521  0.68907563 0.60504202 0.58823529]\n",
+      "Average Score of CVs:  0.6258543417366946\n",
       "Accuracy: 0.6576271186440678\n",
       "\n",
       "Confusion Matrix\n",
@@ -935,8 +1069,7 @@
       "True Positives 3\n",
       "\n",
       "FPR 0.0\n",
-      "FNR 0.9711538461538461\n",
-      "{'DecisionTreeClassifier': (0.2198952879581152, 0.2403846153846154), 'KNeighborsClassifier': (0.18848167539267016, 0.5769230769230769), 'MLPClassifier': (0.1256544502617801, 0.3269230769230769), 'SVC': (0.12041884816753927, 0.25), 'LinearSVC': (0.04712041884816754, 0.6730769230769231), 'LogisticRegression': (0.12041884816753927, 0.28846153846153844), 'Perceptron': (0.0, 0.9711538461538461)}\n"
+      "FNR 0.9711538461538461\n"
      ]
     }
    ],
@@ -947,13 +1080,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 173,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Fold:1, Train set: 476, Test set:120\n",
+      "Fold:2, Train set: 477, Test set:119\n",
+      "Fold:3, Train set: 477, Test set:119\n",
+      "Fold:4, Train set: 477, Test set:119\n",
+      "Fold:5, Train set: 477, Test set:119\n",
+      "Scores for each fold are: [0.88333333 0.78991597 0.80672269 0.80672269 0.79831933]\n",
+      "Average Score of CVs:  0.8170028011204481\n",
       "Accuracy: 0.8406779661016949\n",
       "\n",
       "Confusion Matrix\n",
@@ -966,8 +1106,7 @@
       "True Positives 80\n",
       "\n",
       "FPR 0.12041884816753927\n",
-      "FNR 0.23076923076923078\n",
-      "{'DecisionTreeClassifier': (0.2198952879581152, 0.2403846153846154), 'KNeighborsClassifier': (0.18848167539267016, 0.5769230769230769), 'MLPClassifier': (0.1256544502617801, 0.3269230769230769), 'SVC': (0.12041884816753927, 0.25), 'LinearSVC': (0.04712041884816754, 0.6730769230769231), 'LogisticRegression': (0.12041884816753927, 0.28846153846153844), 'Perceptron': (0.0, 0.9711538461538461), 'RidgeClassifier': (0.12041884816753927, 0.23076923076923078)}\n"
+      "FNR 0.23076923076923078\n"
      ]
     }
    ],
@@ -978,27 +1117,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 174,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Accuracy: 0.7457627118644068\n",
+      "Fold:1, Train set: 476, Test set:120\n",
+      "Fold:2, Train set: 477, Test set:119\n",
+      "Fold:3, Train set: 477, Test set:119\n",
+      "Fold:4, Train set: 477, Test set:119\n",
+      "Fold:5, Train set: 477, Test set:119\n",
+      "Scores for each fold are: [0.41666667 0.44537815 0.63865546 0.6302521  0.58823529]\n",
+      "Average Score of CVs:  0.5438375350140057\n",
+      "Accuracy: 0.6779661016949152\n",
       "\n",
       "Confusion Matrix\n",
-      "[[186   5]\n",
-      " [ 70  34]]\n",
+      "[[190   1]\n",
+      " [ 94  10]]\n",
       "\n",
-      "True Negatives 186\n",
-      "False Positives 5\n",
-      "False Negatives 70\n",
-      "True Positives 34\n",
+      "True Negatives 190\n",
+      "False Positives 1\n",
+      "False Negatives 94\n",
+      "True Positives 10\n",
       "\n",
-      "FPR 0.02617801047120419\n",
-      "FNR 0.6730769230769231\n",
-      "{'DecisionTreeClassifier': (0.2198952879581152, 0.2403846153846154), 'KNeighborsClassifier': (0.18848167539267016, 0.5769230769230769), 'MLPClassifier': (0.1256544502617801, 0.3269230769230769), 'SVC': (0.12041884816753927, 0.25), 'LinearSVC': (0.04712041884816754, 0.6730769230769231), 'LogisticRegression': (0.12041884816753927, 0.28846153846153844), 'Perceptron': (0.0, 0.9711538461538461), 'RidgeClassifier': (0.12041884816753927, 0.23076923076923078), 'SGDClassifier': (0.02617801047120419, 0.6730769230769231)}\n"
+      "FPR 0.005235602094240838\n",
+      "FNR 0.9038461538461539\n"
      ]
     }
    ],
@@ -1016,27 +1161,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 175,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Accuracy: 0.8101694915254237\n",
+      "Fold:1, Train set: 476, Test set:120\n",
+      "Fold:2, Train set: 477, Test set:119\n",
+      "Fold:3, Train set: 477, Test set:119\n",
+      "Fold:4, Train set: 477, Test set:119\n",
+      "Fold:5, Train set: 477, Test set:119\n",
+      "Scores for each fold are: [0.86666667 0.79831933 0.79831933 0.84033613 0.81512605]\n",
+      "Average Score of CVs:  0.8237535014005604\n",
+      "Accuracy: 0.8135593220338984\n",
       "\n",
       "Confusion Matrix\n",
-      "[[161  30]\n",
-      " [ 26  78]]\n",
+      "[[163  28]\n",
+      " [ 27  77]]\n",
       "\n",
-      "True Negatives 161\n",
-      "False Positives 30\n",
-      "False Negatives 26\n",
-      "True Positives 78\n",
+      "True Negatives 163\n",
+      "False Positives 28\n",
+      "False Negatives 27\n",
+      "True Positives 77\n",
       "\n",
-      "FPR 0.15706806282722513\n",
-      "FNR 0.25\n",
-      "{'DecisionTreeClassifier': (0.2198952879581152, 0.2403846153846154), 'KNeighborsClassifier': (0.18848167539267016, 0.5769230769230769), 'MLPClassifier': (0.1256544502617801, 0.3269230769230769), 'SVC': (0.12041884816753927, 0.25), 'LinearSVC': (0.04712041884816754, 0.6730769230769231), 'LogisticRegression': (0.12041884816753927, 0.28846153846153844), 'Perceptron': (0.0, 0.9711538461538461), 'RidgeClassifier': (0.12041884816753927, 0.23076923076923078), 'SGDClassifier': (0.02617801047120419, 0.6730769230769231), 'RandomForestClassifier': (0.15706806282722513, 0.25)}\n"
+      "FPR 0.14659685863874344\n",
+      "FNR 0.25961538461538464\n"
      ]
     }
    ],
@@ -1047,13 +1198,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 176,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Fold:1, Train set: 476, Test set:120\n",
+      "Fold:2, Train set: 477, Test set:119\n",
+      "Fold:3, Train set: 477, Test set:119\n",
+      "Fold:4, Train set: 477, Test set:119\n",
+      "Fold:5, Train set: 477, Test set:119\n",
+      "Scores for each fold are: [0.86666667 0.81512605 0.8487395  0.84033613 0.79831933]\n",
+      "Average Score of CVs:  0.8338375350140057\n",
       "Accuracy: 0.8338983050847457\n",
       "\n",
       "Confusion Matrix\n",
@@ -1066,8 +1224,7 @@
       "True Positives 81\n",
       "\n",
       "FPR 0.13612565445026178\n",
-      "FNR 0.22115384615384615\n",
-      "{'DecisionTreeClassifier': (0.2198952879581152, 0.2403846153846154), 'KNeighborsClassifier': (0.18848167539267016, 0.5769230769230769), 'MLPClassifier': (0.1256544502617801, 0.3269230769230769), 'SVC': (0.12041884816753927, 0.25), 'LinearSVC': (0.04712041884816754, 0.6730769230769231), 'LogisticRegression': (0.12041884816753927, 0.28846153846153844), 'Perceptron': (0.0, 0.9711538461538461), 'RidgeClassifier': (0.12041884816753927, 0.23076923076923078), 'SGDClassifier': (0.02617801047120419, 0.6730769230769231), 'RandomForestClassifier': (0.15706806282722513, 0.25), 'GradientBoostingClassifier': (0.13612565445026178, 0.22115384615384615)}\n"
+      "FNR 0.22115384615384615\n"
      ]
     }
    ],
@@ -1078,27 +1235,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 177,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Accuracy: 0.8135593220338984\n",
+      "Fold:1, Train set: 476, Test set:120\n",
+      "Fold:2, Train set: 477, Test set:119\n",
+      "Fold:3, Train set: 477, Test set:119\n",
+      "Fold:4, Train set: 477, Test set:119\n",
+      "Fold:5, Train set: 477, Test set:119\n",
+      "Scores for each fold are: [0.875      0.78151261 0.78991597 0.82352941 0.76470588]\n",
+      "Average Score of CVs:  0.8069327731092436\n",
+      "Accuracy: 0.823728813559322\n",
       "\n",
       "Confusion Matrix\n",
-      "[[162  29]\n",
-      " [ 26  78]]\n",
+      "[[164  27]\n",
+      " [ 25  79]]\n",
       "\n",
-      "True Negatives 162\n",
-      "False Positives 29\n",
-      "False Negatives 26\n",
-      "True Positives 78\n",
+      "True Negatives 164\n",
+      "False Positives 27\n",
+      "False Negatives 25\n",
+      "True Positives 79\n",
       "\n",
-      "FPR 0.1518324607329843\n",
-      "FNR 0.25\n",
-      "{'DecisionTreeClassifier': (0.2198952879581152, 0.2403846153846154), 'KNeighborsClassifier': (0.18848167539267016, 0.5769230769230769), 'MLPClassifier': (0.1256544502617801, 0.3269230769230769), 'SVC': (0.12041884816753927, 0.25), 'LinearSVC': (0.04712041884816754, 0.6730769230769231), 'LogisticRegression': (0.12041884816753927, 0.28846153846153844), 'Perceptron': (0.0, 0.9711538461538461), 'RidgeClassifier': (0.12041884816753927, 0.23076923076923078), 'SGDClassifier': (0.02617801047120419, 0.6730769230769231), 'RandomForestClassifier': (0.15706806282722513, 0.25), 'GradientBoostingClassifier': (0.13612565445026178, 0.22115384615384615), 'BaggingClassifier': (0.11518324607329843, 0.27884615384615385), 'ExtraTreesClassifier': (0.1518324607329843, 0.25)}\n"
+      "FPR 0.14136125654450263\n",
+      "FNR 0.2403846153846154\n"
      ]
     }
    ],
@@ -1109,27 +1272,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 178,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Accuracy: 0.8338983050847457\n",
+      "Fold:1, Train set: 476, Test set:120\n",
+      "Fold:2, Train set: 477, Test set:119\n",
+      "Fold:3, Train set: 477, Test set:119\n",
+      "Fold:4, Train set: 477, Test set:119\n",
+      "Fold:5, Train set: 477, Test set:119\n",
+      "Scores for each fold are: [0.84166667 0.76470588 0.78991597 0.79831933 0.79831933]\n",
+      "Average Score of CVs:  0.7985854341736693\n",
+      "Accuracy: 0.8271186440677966\n",
       "\n",
       "Confusion Matrix\n",
-      "[[168  23]\n",
-      " [ 26  78]]\n",
+      "[[165  26]\n",
+      " [ 25  79]]\n",
       "\n",
-      "True Negatives 168\n",
-      "False Positives 23\n",
-      "False Negatives 26\n",
-      "True Positives 78\n",
+      "True Negatives 165\n",
+      "False Positives 26\n",
+      "False Negatives 25\n",
+      "True Positives 79\n",
       "\n",
-      "FPR 0.12041884816753927\n",
-      "FNR 0.25\n",
-      "{'DecisionTreeClassifier': (0.2198952879581152, 0.2403846153846154), 'KNeighborsClassifier': (0.18848167539267016, 0.5769230769230769), 'MLPClassifier': (0.1256544502617801, 0.3269230769230769), 'SVC': (0.12041884816753927, 0.25), 'LinearSVC': (0.04712041884816754, 0.6730769230769231), 'LogisticRegression': (0.12041884816753927, 0.28846153846153844), 'Perceptron': (0.0, 0.9711538461538461), 'RidgeClassifier': (0.12041884816753927, 0.23076923076923078), 'SGDClassifier': (0.02617801047120419, 0.6730769230769231), 'RandomForestClassifier': (0.15706806282722513, 0.25), 'GradientBoostingClassifier': (0.13612565445026178, 0.22115384615384615), 'BaggingClassifier': (0.12041884816753927, 0.25), 'ExtraTreesClassifier': (0.1518324607329843, 0.25)}\n"
+      "FPR 0.13612565445026178\n",
+      "FNR 0.2403846153846154\n"
      ]
     }
    ],
@@ -1140,7 +1309,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 179,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1150,21 +1319,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 180,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'y_pred' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "Input \u001b[0;32mIn [51]\u001b[0m, in \u001b[0;36m<cell line: 40>\u001b[0;34m()\u001b[0m\n\u001b[1;32m     36\u001b[0m     plt\u001b[38;5;241m.\u001b[39mtight_layout()\n\u001b[1;32m     39\u001b[0m \u001b[38;5;66;03m# Compute confusion matrix\u001b[39;00m\n\u001b[0;32m---> 40\u001b[0m cnf_matrix \u001b[38;5;241m=\u001b[39m confusion_matrix(y_truth, \u001b[43my_pred\u001b[49m)\n\u001b[1;32m     41\u001b[0m class_names\u001b[38;5;241m=\u001b[39m[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m0\u001b[39m\u001b[38;5;124m'\u001b[39m, \u001b[38;5;124m'\u001b[39m\u001b[38;5;124m1\u001b[39m\u001b[38;5;124m'\u001b[39m]\n\u001b[1;32m     42\u001b[0m np\u001b[38;5;241m.\u001b[39mset_printoptions(precision\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m2\u001b[39m)\n",
-      "\u001b[0;31mNameError\u001b[0m: name 'y_pred' is not defined"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import itertools\n",
     "import matplotlib.pyplot as plt\n",
@@ -1203,55 +1360,38 @@
     "    plt.xlabel('Predicted label')\n",
     "    plt.tight_layout()\n",
     "\n",
+    "def show_matrix(model):\n",
+    "    y_pred = model.predict(X_test)\n",
+    "    # Compute confusion matrix\n",
+    "    cnf_matrix = confusion_matrix(y_truth, y_pred)\n",
+    "    class_names=['0', '1']\n",
+    "    np.set_printoptions(precision=2)\n",
     "\n",
-    "# Compute confusion matrix\n",
-    "cnf_matrix = confusion_matrix(y_truth, y_pred)\n",
-    "class_names=['0', '1']\n",
-    "np.set_printoptions(precision=2)\n",
+    "    # Plot non-normalized confusion matrix\n",
+    "    plt.figure()\n",
+    "    plot_confusion_matrix(cnf_matrix, classes=class_names,\n",
+    "                        title='Confusion matrix, without normalization')\n",
     "\n",
-    "# Plot non-normalized confusion matrix\n",
-    "plt.figure()\n",
-    "plot_confusion_matrix(cnf_matrix, classes=class_names,\n",
-    "                      title='Confusion matrix, without normalization')\n",
+    "    plt.show()\n",
     "\n",
-    "plt.show()"
+    "show_matrix(knn_clf)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 228,
    "metadata": {},
    "outputs": [],
    "source": [
-    "predictions = svm_clf.predict(test_data.values)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "type(predictions)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pred_df = pd.DataFrame(predictions, index=test_data.index, columns=['Survived'])\n",
-    "type(pred_df)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pred_df.to_csv('predictions.csv', header=True, sep=',')"
+    "def create_pred_csv(model):\n",
+    "    predictions = model.predict(test_data.values)\n",
+    "    pred_df = pd.DataFrame(predictions, index=test_data.index, columns=['Survived'])\n",
+    "    type(pred_df)\n",
+    "    pred_df.to_csv(str(model.__name__) + 'predictions.csv', header=True, sep=',')\n",
+    "\n",
+    "\n",
+    "# think the test_data has NaN so it really doesn't like it\n",
+    "create_pred_csv(knn_clf)"
    ]
   },
   {
@@ -1260,17 +1400,65 @@
    "source": [
     "## Function to display pareto front\n",
     "\n",
-    "We will give it the model dict and all the fpr and fnr that we have"
+    "We will give it the model dict and all the fpr and fnr that we have\n",
+    "\n",
+    "https://oapackage.readthedocs.io/en/latest/examples/example_pareto.html\n",
+    "\n",
+    "https://stackoverflow.com/questions/21294829/fast-calculations-of-the-pareto-front-in-r\n",
+    "\n",
+    "The trick here is to sort by x, which then allows you to limit your check to making sure that all prior values of x must have greater values of y to ensure that point is on the frontier."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 222,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'MLPClassifier': (0.09424083769633508, 0.4423076923076923), 'SVC': (0.12041884816753927, 0.25), 'LinearSVC': (0.09424083769633508, 0.3942307692307692), 'LogisticRegression': (0.12041884816753927, 0.28846153846153844), 'Perceptron': (0.0, 0.9711538461538461), 'RidgeClassifier': (0.12041884816753927, 0.23076923076923078), 'SGDClassifier': (0.005235602094240838, 0.9038461538461539), 'GradientBoostingClassifier': (0.13612565445026178, 0.22115384615384615)}\n"
+     ]
+    }
+   ],
+   "source": [
+    "def create_models_df(models):\n",
+    "    df = pd.DataFrame(columns = ['model', 'fpr', 'fnr'])\n",
+    "    for model in models:\n",
+    "        fpr, fnr = models[model]\n",
+    "        df.loc[len(df.index)] = [model, fpr, fnr]\n",
+    "    return df\n",
+    "\n",
+    "def find_hof(df):\n",
+    "    out = {}\n",
+    "    for index, row in df.iterrows():\n",
+    "        # look at all the models with a higher fpr\n",
+    "        tmp = df[df.fpr < row['fpr']]\n",
+    "        # drop the ones with a higher fnr\n",
+    "        tmp = tmp[tmp.fnr <= row['fnr']]\n",
+    "        # not optimal\n",
+    "        if tmp.size == 0:\n",
+    "            model = row['model']\n",
+    "            fpr = row['fpr']\n",
+    "            fnr = row['fnr']\n",
+    "            out[model] = (fpr, fnr)\n",
+    "    return out\n",
+    "\n",
+    "\n",
+    "df = create_models_df(models)\n",
+    "hof = find_hof(df)\n",
+    "print(hof)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 226,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAeAAAAEWCAYAAAC+H0SRAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAABMTElEQVR4nO3deZyNZf/A8c93FsYsxjYky1iyNOvBzCCyJMrepiyF0iPh0VM/Hi1KipZHeymPFvRQJCWFFlJSwmBshcaWLUYYxlhm+f7+OGdOM2MwluOM6ft+vc7Lua/7uq/7e+455jvXvVyXqCrGGGOMubR8vB2AMcYY83dkCdgYY4zxAkvAxhhjjBdYAjbGGGO8wBKwMcYY4wWWgI0xxhgvsARsjDHGeIElYHNZE5FtInJMRNJEZK+ITBSRYA/sZ5KIjL6A7b8TkeOuOHNeTS9yjK1EZOfFbNMY4zmWgE1x0FlVg4GGQDww4lw2FqdL8X9hsKoG53otyReH3yWIwRhTRFgCNsWGqu4C5gFRIlJWRL4QkRQROeh6XzWnrqtHOkZEfgTSgVoiUl9EvhGRAyKyUURud9XtD/QC/u3quX7uKr/a1c4hEVkvIl3ONWZXD364iKwBjoqIn4h0cbV3yNX+1fnqDxWRNSKSKiLTRSRARIJcn/3KXD3sKy/gcBpjPMwSsCk2RKQa0AFYhfO7PREIB6oDx4A38m1yF9AfCAFSgG+AD4CKQA/gTRGJVNUJwFTgP66ea2cR8Qc+B7521f8nMFVE6p1H6D2AjkAZoBbwIfAvIAyYC3wuIiVy1b8duBGoCcQAfVX1KNAe2J2rh737PGIxxlwiloBNcTBLRA4Bi4HvgWdU9U9Vnamq6ap6BBgDtMy33SRVXa+qmTgT2jZVnaiqmaq6EpgJ3HaafTYBgoHnVPWkqn4LfIEzmZ7Oa65e7SERWZm7XFV3qOox4A5gjqp+o6oZwAtAKeCafPV3q+oBnH8EOM5yfIwxRZBdczLFwU2qOj93gYgEAi/jTKxlXcUhIuKrqlmu5R25NgkHGrsSeQ4/4H+n2eeVwA5Vzc5Vth2ocoY4h6jqOwWU547jSlc7AKhqtojsyNfuH7nep7u2McZcZiwBm+Lq/4B6QGNV/UNEHDhPTUuuOrmnAtsBfK+qbU/TXv5pw3YD1UTEJ1cSrg5sOo9Yc7e9G4jOWRARAaoBu86xHWNMEWenoE1xFYLzuu8hESkHjDxL/S+AuiJyl4j4u17xuW6A2ovz+myOpcBRnDdm+YtIK6AzMO0C4/4I6CgibVzXmf8POAH8VIht9wLlRST0AmMwxlwCloBNcfUKzmun+4GfgS/PVNl1nbgd0B1nL/QP4HmgpKvKu0CE6/rtLFU9CXTBeePTfuBNoLeqbriQoFV1I3An8Lqr3c44H7M6WYhtN+C8gWuLK047NW1MESaqdtbKGGOMudSsB2yMMcZ4gSVgY4wxxgssARtjjDFe4LEELCLvicg+EVl3mvUiIq+JSLJrWL2GnorFGGOMKWo8+RzwJJxD/71/mvXtgTquV2PgLde/Z1ShQgWtUaPGxYnQGGP+JlasWLFfVcO8HYf5i8cSsKouEpEaZ6jSFXhfnbdh/ywiZUSksqruOVO7NWrUIDEx8WKGaowxxZ6IbD97LXMpefMacBXyDsG3kzMP42eMMcYUG95MwFJAWYEPJYtIfxFJFJHElJSUC9qpr68vDoeDqKgounXrRnp6+gW1dz5mzZrFL7/8csn3a4wxpujwZgLeiXOM2xxVcY5AdApVnaCqcaoaFxZ2YZcwSpUqRVJSEuvWraNEiRKMHz++UNtlZmZe0H5zO1MCvpj7McYYU3R5MwHPBnq77oZuAqSe7frvxXbttdeSnJzM0aNHueeee4iPj6dBgwZ89tlnAEyaNIlu3brRuXNn2rVrR1paGnfffTfR0dHExMQwc+ZMAL7++muaNm1Kw4YN6datG2lpaYDzevXw4cNJSEggISGB5ORkfvrpJ2bPns2wYcNwOBxs3ryZVq1a8eijj9KyZUteffVVFixYQIMGDYiOjuaee+7hxIkT7vZGjhxJw4YNiY6OZsOGCxr10BhjjBd58jGkD4ElQD0R2Ski/URkgIgMcFWZC2wBkoG3gYGeiqUgmZmZzJs3j+joaMaMGcN1113H8uXLWbhwIcOGDePo0aMALFmyhMmTJ/Ptt9/y9NNPExoaytq1a1mzZg3XXXcd+/fvZ/To0cyfP5+VK1cSFxfHSy+95N5P6dKlWbZsGYMHD+Zf//oX11xzDV26dGHs2LEkJSVRu3ZtAA4dOsT333/PoEGD6Nu3L9OnT2ft2rVkZmby1ltvudurUKECK1eu5P777+eFF164lIfMGGPMReTJu6DPNDE5rrufB3lq/7lNnQqPPQa//w6qxwgPd1C2rLMH3K9fP6655hpmz57tTmjHjx/n999/B6Bt27aUK1cOgPnz5zNt2l+T3ZQtW5YvvviCX375hWbNmgFw8uRJmjZt6q7To0cP978PPvjgaWO84447ANi4cSM1a9akbt26APTp04dx48bxr3/9C4BbbrkFgEaNGvHJJ59c8LExxhjjHcV+PuCpU6F/f/jrXqtS7N+fxDPPQK9ezhJVZebMmdSrVy/PtkuXLiUoKMi9rKo4p2clT1nbtm358MMPC9x/7vr5t80tZz9nmxyjZEnn5Dy+vr52vdgYYy5jxX4oyscey518ndLTneU5brjhBl5//XV38lu1alWBbbVr14433njDvXzw4EGaNGnCjz/+SHJysqvtdDZt+mtO9unTp7v/zekZh4SEcOTIkQL3Ub9+fbZt2+Zu73//+x8tW7Y8h09sjDHmclDsE7DrTPIZyx9//HEyMjKIiYkhKiqKxx9/vMBtRowYwcGDB4mKiiI2NpaFCxcSFhbGpEmT6NGjBzExMTRp0iTPzVEnTpygcePGvPrqq7z88ssAdO/enbFjx9KgQQM2b96cZx8BAQFMnDiRbt26ER0djY+PDwMGDMAYY0zxctnNBxwXF6fnMhJWjRqwvYDxX8LDYdu2ixbWafbtHLWrQoUKnt2RMcachYisUNU4b8dh/lLse8BjxkBgYN6ywEBnuTHGGOMtxT4B9+oFEyY4e7wizn8nTPjrBixP2rZtm/V+jTHGFKjY3wUNzmR7KRKuMcYYU1jFvgdsjDHGFEWWgI0xxhgvsARsjDHGeIElYGOMMcYLLAEbY4wxXmAJ2BhjjPECS8DGGGOMF1gCNsYYY7zAErAxxhjjBZaAjTHGGC+wBGyMMcZ4gUcTsIjcKCIbRSRZRB4uYH1ZEflURNaIyDIRifJkPMYYY0xR4bEELCK+wDigPRAB9BCRiHzVHgWSVDUG6A286ql4jDHGmKLEkz3gBCBZVbeo6klgGtA1X50IYAGAqm4AaohIJQ/GZIwxxhQJnkzAVYAduZZ3uspyWw3cAiAiCUA4UDV/QyLSX0QSRSQxJSXFQ+EaY4wxl44nE7AUUKb5lp8DyopIEvBPYBWQecpGqhNUNU5V48LCwi56oMYYY8yl5ufBtncC1XItVwV2566gqoeBuwFERICtrpcxxhhTrHmyB7wcqCMiNUWkBNAdmJ27goiUca0DuBdY5ErKxhhjTLHmsR6wqmaKyGDgK8AXeE9V14vIANf68cDVwPsikgX8AvTzVDzGGGNMUeLJU9Co6lxgbr6y8bneLwHqeDIGY4wxpiiykbCMMcYYL7AEbIwxxniBJWBjjDHGCywBG2OMMV5gCdgYY4zxAkvAxhhjjBdYAjbGGGO8wBKwMcYY4wWWgI0xxhgvsARsjDHGeIElYGOMMcYLLAEbY4wxXmAJ2BhjjPECS8DGGGOMF1gCNsYYY7zAErAxxhjjBZaAjTHGGC/waAIWkRtFZKOIJIvIwwWsDxWRz0VktYisF5G7PRmPMcYYU1R4LAGLiC8wDmgPRAA9RCQiX7VBwC+qGgu0Al4UkRKeiskYY4wpKjzZA04AklV1i6qeBKYBXfPVUSBERAQIBg4AmR6MyRhjjCkSPJmAqwA7ci3vdJXl9gZwNbAbWAs8oKrZ+RsSkf4ikigiiSkpKZ6K1xhjjLlkPJmApYAyzbd8A5AEXAk4gDdEpPQpG6lOUNU4VY0LCwu72HEaY4wxl5wnE/BOoFqu5ao4e7q53Q18ok7JwFagvgdjMsYYY4oETybg5UAdEanpurGqOzA7X53fgTYAIlIJqAds8WBMxhhjTJHg56mGVTVTRAYDXwG+wHuqul5EBrjWjweeBiaJyFqcp6yHq+p+T8VkjDHGFBUeS8AAqjoXmJuvbHyu97uBdp6MwRhjjCmKbCQsY4wxxgssARtjjDFeYAnYGGOM8QJLwMYYY4wXWAI2xhhjvMASsDHGGOMFloCNMcYYL7AEbIwxxniBJWBjjDHGCywBG2OMMV5gCdgYY4zxAkvAxhhjjBdYAjbGGGO8wBKwMcYY4wWWgI0xxhgvsARsjDHGeIElYGOMMcYLLAEbY4wxXuDRBCwiN4rIRhFJFpGHC1g/TESSXK91IpIlIuU8GZMxxhhTFHgsAYuILzAOaA9EAD1EJCJ3HVUdq6oOVXUAjwDfq+oBT8VkjDHGFBWe7AEnAMmqukVVTwLTgK5nqN8D+NCD8RhjjDFFhicTcBVgR67lna6yU4hIIHAjMPM06/uLSKKIJKakpFz0QL1tzJgxREZGEhMTg8PhYOnSpWRmZvLoo49Sp04dHA4HDoeDMWPGuLfx9fXF4XAQGRlJbGwsL730EtnZ2e71y5Yto0WLFtSrV4/69etz7733kp6ezqRJkxg8eDDBwcGnxDF+/Hjef//9c4q9Q4cOHDp0CIDXXnuNq6++ml69ejF79myee+65Ard57733iI6OJiYmhqioKD777DMmTZpEjx498tTbv38/YWFhnDhxgoyMDB5++GHq1KlDVFQUCQkJzJs375xiNcaYosTPg21LAWV6mrqdgR9Pd/pZVScAEwDi4uJO18ZlacmSJXzxxResXLmSkiVLsn//fk6ePMmIESP4448/WLt2LQEBARw5coQXX3zRvV2pUqVISkoCYN++ffTs2ZPU1FRGjRrF3r176datG9OmTaNp06aoKjNnzuTIkSNnjGXAgAHnHP/cuXPd7998803mzZtHzZo1AejSpUueuqrKjh07GDNmDCtXriQ0NJS0tDRSUlIIDQ1l6NChpKenExgYCMDHH39Mly5dKFmyJA8//DB79uxh3bp1lCxZkr179/L999+fc7zGGFNUeDIB7wSq5VquCuw+Td3u/E1PP+/Zs4cKFSpQsmRJACpUqEB6ejpvv/0227ZtIyAgAICQkBCefPLJAtuoWLEiEyZMID4+nieffJJx48bRp08fmjZtCoCIcNttt52y3eeff87o0aM5efIk5cuXx+FwcMUVVxAfH0/Hjh0JCgoiLS2NypUrM3bsWF5++WUOHz7Mzp07qVChAiVKlGDXrl1s3LiR4cOHs2nTJiIiIihTpgzdunUjOzuboUOH0rZtW7Kysvjjjz+oXr06Pj4+BAcH8+STT7J79262bdtGhQoVaNGiBZ9//jl33HEHANOmTWPEiBHu47F161b3capUqRK33377xf5xGGPMJePJU9DLgToiUlNESuBMsrPzVxKRUKAl8JkHYymy2rVrx44dO6hbty4DBw7k+++/Jzk5merVqxMSElLodmrVqkV2djb79u1j3bp1NGrU6KzbNG/enJ9//plVq1bRvXt3fvzxRwBeeOEF6tSpw5133snevXt5+eWX+fe//80NN9zAwIEDGTJkCMuXL2f58uWkpaWxfft2/vvf/1KtWjV27NjB2rVrmTZtGqrOkxXJyckMHz6c9PR05s2bx549e6hZsyazZs3i22+/5bPPPuODDz6gR48eTJs2DYDdu3ezadMmWrdu7T4epUuXPo8jbIwxRZPHErCqZgKDga+AX4GPVHW9iAwQkdznOm8GvlbVo56KpSiaOhVq1IDSpYM5eHAF3bpNICwsjDvuuIPvvvsuT92JEyficDjcCe50chLemfY5dCiMGwfp6fDf/+7khhtuIDo6mrFjx5Jzfb1Zs2Zs3ryZrKwsDh06REJCAunp6UycOJFXXnmFd999l2uvvZbGjRuTlZXFli1bUFUOHjxIixYtuP766zl48CDHjh0DwMfHh7feeguHw8HNN99MaGgokydPpnz58hw4cIDnn38egE6dOrF48WIOHz7MRx99xG233Yavr+/5H2RjjCnKVPWyejVq1Egvd1OmqAYGqsJfr8BAZ/mMGTP0+uuv13Llyunhw4fzbBcZGalbt25VVdWgoKA86zZv3qzlypXT7OxsHTFihD7++OOn2edEhUEKQerj01IffPAzVVVduHChhoeH69ixY1VVtVGjRjp48GCtUqWK/vTTTxoeHq67du3SBg0aaI0aNXTy5MmqqhoeHq4pKSk6ceJEDQwM1N27d6uqavny5fWuu+7SrVu3qq+vr6anp59yHEaOHKlDhgzRqKgod9mdd96pkyZN0saNG+tPP/2kqqpHjx4t8HgYYwoPSNQi8DvcXn+9bCQsL3jsMWcP1Gkj8Bvp6c7ypKQk6tWrR79+/Rg8eDDHjx8HICsri5MnTxbYXkpKCgMGDGDw4MGICIMHD2by5MksXbrUXeeBB6aQnv5Hnu2ys1P58EPnjemTJ092l2/evJng4GD69OlDXFwcv/32G5mZmVSsWJEBAwYQHBxMYmIiAJmZmRw9epTU1FR8fX3x9/dn4cKF/Pnnn+72goODeeONNwDnqeUPP/zrcv/u3bsJDw93L/fo0YOXXnqJvXv30qRJEwACAwPp168fQ4YMcR+DPXv2MGXKlMIecmOMKXI8eROWOY3ff8+9lAb8EzjE9u1+/PLLVUyYMIHQ0FAef/xxoqKiCAkJoVSpUvTp04crr7wSgGPHjuFwOMjIyMDPz4+77rqLhx56CHDeoDRt2jSGDh3Kvn378PHx4c8/WwC35NpvOvA7f/zRmJIlfbnmmmvca1555RWWL19Oz549adSoEW3atOH48eM4HA78/f05dOgQX331FVFRUezfv5+srCx69erFv//9b66//nri4uK44oor3O1dccUVJCYmEhMTw7Fjx0hPT2fUqFEcOnSI0qVL53mcqF27dvTp04d+/foh8teN9KNHj2bEiBFEREQQEBBAUFAQTz311EX7mRhjzKUmzjMTl4+4uDjN6X1drmrUgO3bTy0PD4dt24rPPo0xRYeIrFDVOG/HYf5ip6C9YMwYcD3q6hYY6CwvTvs0xhhzepaAvaBXL5gwwdn7FHH+O2GCs7w47dMYY8zp2SloY4z5G7BT0EWP9YCNMcYYL7AEbIwxxniBJWBjjDHGCywBG2OMMV5gCdgYY4zxAkvAxhhjjBdYAjbGGGO8wBKwMcYY4wXnnYBFJPzstYwxxhhTkLMmYBFpKiK3iUhF13KMiHwALPZ4dMYYY0wxdcYELCJjgfeAW4E5IjIS+AZYCtTxfHjGGGNM8XS2+YA7Ag1U9biIlAV2AzGq+lthGheRG4FXAV/gHVV9roA6rYBXAH9gv6q2LHT0xhhjzGXqbAn4mKoeB1DVgyKy8RySry8wDmgL7ASWi8hsVf0lV50ywJvAjar6e85pbmOMMaa4O9s14NoiMtv1+hyokWt59lm2TQCSVXWLqp4EpgFd89XpCXyiqr8DqOq+8/kQxhhzvoKDg93v586dS506dfj999958sknCQwMZN++fQXWPZ0OHTpw6NChM9Zp1aoVBc3qNmnSJAYPHlz44M9NJRHZICLrRGS1iPQGEJHvROSizJIkInEi8prrfUkRmS8iSSJyh4i8IyIRF2M/xcXZesD5E+YL59B2FWBHruWdQON8deoC/iLyHRACvKqq7+dvSET6A/0Bqlevfg4hGGNM4SxYsIB//vOffP311+7fMxUqVODFF1/k+eefL3Q7c+fO9VSIZ6SqqCo+Pqf2q8aPHw9QGohU1cMiEgrc5IEYEoGcvywaAP6q6nAtTz+XtkTEV1WzLmJ4Rc4Ze8Cq+j1wGAgD9qnq97lfZ2lbCmoy37If0AjnteYbgMdFpG4BcUxQ1ThVjQsLCzvLbo0x5tz88MMP/OMf/2DOnDnUrl3bXX7PPfcwffp0Dhw4cMo2U6ZMISEhAYfDwX333UdWljNX1KhRg/379wPw9NNPU79+fdq2bUuPHj144YW/+jAzZswgISGBunXr8sMPP7jLd+zYwY033ki9evUYNWqUu/yll14iKiqKqKgoXnnlFQC2bdvG1VdfzcCBA2nYsCE7duygb9++REVFER0dzcsvvwzAM888A/C7qh4GUNVUVZ2c/zOJyFsikigi60VkVK7y50TkFxFZIyIvuMq65epNL3KVtRKRL1yXE6cADlcPuHbunraItBORJSKyUkRmiEiwq3ybiDwhIouBboX88V22ztgDFpEngDuBFcB/RORZVX27kG3vBKrlWq6K8yau/HX2q+pR4KjrhxgLbCrkPowx5oKcOHGCrl278t1331G/fv0864KDg7nnnnt49dVX8yTDX3/9lenTp/Pjjz/i7+/PwIEDmTp1Kr1793bXSUxMZObMmaxatYrMzEwaNmxIo0aN3OszMzNZtmwZc+fOZdSoUcyfPx+AZcuWsW7dOgIDA4mPj6djx46ICBMnTmTp0qWoKo0bN6Zly5aULVuWjRs3MnHiRN58801WrFjBrl27WLduHQCHDh3iyJEjHDlyBOBEIQ7HY6p6wHUPzwIRicH5e/pmoL6qquveHYAngBtUdVeuMsB5OVFE7gWGqmonABFnn0xEKgAjgOtV9aiIDAceAp5ybX5cVZsXItbL3tmuAd8BOFS1BxCP6zRwIS0H6ohITREpAXQH8l83/gy4VkT8RCQQ5ynqX89hH8YYc86mToUaNcDHB7Ky/AkPv4Z33323wLpDhgxh8uTJHD582F22YMECVqxYQXx8PA6HgwULFrBly5Y82y1evJiuXbtSqlQpQkJC6Ny5c571t9xyCwCNGjVi27Zt7vK2bdtSvnx5SpUqxS233MLixYtZvHgxN998M0FBQQQHB3PLLbe4e83h4eE0adIEgFq1arFlyxb++c9/8uWXX1K6dGlU1Z38CuF2EVkJrAIigQicZ0GPA++IyC1Auqvuj8AkEfkHziddCquJq90fRSQJ6APkHtjpnE5VX87Odg34uKqmA6jqnyJS6JGzVDVTRAYDX+H84bynqutFZIBr/XhV/VVEvgTWANk4H1Vad16fxBhjCmHqVOjfH9Jz0gg+bNz4EUePXk+lSs/w6KOP5qlfpkwZevbsyZtvvukuU1X69OnDs88+e9r9qOa/4pZXyZIlAfD19SUzM9Ndnj9ZisgZ2woKCnK/L1u2LKtXr+arr75i3LhxfPTRR7z33nsEBQVx8ODBEmeKR0RqAkOBeNdTL5OAANfv8gSgDc6O1GDgOlUdICKNcV5CTBIRxxk/cK5dAd+4OnYFOVrIdi5753oXdO7ls90FjarOVdW6qlpbVce4ysar6vhcdcaqaoSqRqnqKxf0aYwx5iweeyx38nU6diyQY8e+YOrUqQX2hB966CH++9//uhNlmzZt+Pjjj913SB84cIDt27fn2aZ58+Z8/vnnHD9+nLS0NObMmVOo+L755hsOHDjAsWPHmDVrFs2aNaNFixbMmjWL9PR0jh49yqeffsq11157yrb79+8nOzubW2+9laeffpqVK1cC8MgjjwCEi0hpABEp7bq5NbfSOJNfqohUAtq76gYDoao6F/gX4HCV11bVpar6BLCfvJccz+RnoJmIXOVqJ7Cge3/+Djx5F7QxxhQ5v/9ecPmuXeX46acvadGiBRUqVMizrkKFCtx8883um5oiIiIYPXo07dq1Izs7G39/f8aNG0d4+F9nUuPj4+nSpQuxsbGEh4cTFxdHaGjoWeNr3rw5d911F8nJyfTs2ZO4OOcTQn379iUhIQGAe++9lwYNGuQ5de38DLu4++67yc7OBnD30O+//34GDRp0GOd4DBlABvBi7m1VdbWIrALWA1twnmIG5xMqn4lIAM7e64Ou8rEiUsdVtgBYDZx1ICVVTRGRvsCHIlLSVTyCv+G9P3KmUxsiUj3nGd2iIi4uTgt6fs4YYwqjRg3I11kFIDwc8uWzC5aWlkZwcDDp6em0aNGCCRMm0LBhw4u7k0ISkRWqelGe9zUXx9lOQc/KeSMiMz0bijHGeN6YMRAYmLcsMNBZfrH1798fh8NBw4YNufXWW72WfE3RdLZT0LnvBqjlyUCMMeZS6NXL+e9jjzlPR1ev7ky+OeUX0wcffHDxGzXFxtkSsJ7mvTHGXLZ69fJMwjXmXJwtAceKyGGcPeFSrve4llVVS3s0OmOMMaaYOmMCVtVzebjaGGOMMYVU6IE1jDHGGHPxWAI2xhhjvMASsDHGGOMFloCNMcYYL7AEbIwxxniBJWBjjDHGCywBG2OMMV5gCdgYY4zxAkvAxhhjjBdYAjbGGGO8wKMJWERuFJGNIpIsIg8XsL6ViKSKSJLr9YQn4zHGGGOKirNNxnDeRMQXGAe0BXYCy0Vktqr+kq/qD6rayVNxGGOMMUWRJ3vACUCyqm5R1ZPANKCrB/dnjDHGXDY8mYCrADtyLe90leXXVERWi8g8EYksqCER6S8iiSKSmJKS4olYjTHGmEvKkwlYCijTfMsrgXBVjQVeB2YV1JCqTlDVOFWNCwsLu7hRGmOMMV7gyQS8E6iWa7kqsDt3BVU9rKpprvdzAX8RqeDBmIwxxpgiwZMJeDlQR0RqikgJoDswO3cFEblCRMT1PsEVz58ejMkYY4wpEjx2F7SqZorIYOArwBd4T1XXi8gA1/rxwG3A/SKSCRwDuqtq/tPUxhhjTLEjl1u+i4uL08TERG+HYYwxlxURWaGqcd6Ow/zFRsIyxhhjvMASsDHGGOMFloCNMcYYL7AEbIwxxniBJWBjjDHGCywBG2OMMV5gCdgYY4zxAkvAxhhjjBdYAjbGGGO8wBKwMcYY4wWWgI0xxhgvsARsjDHGeIElYGOMMcYLLAEbY4wxXmAJ2BhjjPECS8DGGGOMF1gCNsYYY7zAErAxxhjjBR5NwCJyo4hsFJFkEXn4DPXiRSRLRG7zZDzGGGNMUeGxBCwivsA4oD0QAfQQkYjT1Hse+MpTsRhjjDFFjSd7wAlAsqpuUdWTwDSgawH1/gnMBPZ5MBZjjDGmSPFkAq4C7Mi1vNNV5iYiVYCbgfFnakhE+otIoogkpqSkXPRAjTHGmEvNkwlYCijTfMuvAMNVNetMDanqBFWNU9W4sLCwixWfMcYY4zV+Hmx7J1At13JVYHe+OnHANBEBqAB0EJFMVZ3lwbiMMcYYr/NkAl4O1BGRmsAuoDvQM3cFVa2Z815EJgFfWPI1xhjzd+CxBKyqmSIyGOfdzb7Ae6q6XkQGuNaf8bqvMcYYU5x5sgeMqs4F5uYrKzDxqmpfT8ZijDHGFCU2EpYxxhjjBZaAjTHGGC+wBGyMMcZ4gSVgY4wxxgssARtjjDFeYAnYGGOM8QJLwMZcBkSEu+66y72cmZlJWFgYnTp1AmDSpEkMHjz4lO1q1KhBdHQ0sbGxtGvXjj/++AOAtLQ07rvvPmrXrk1kZCQtWrRg6dKlAAQHB1+0uMePH8/7778PwIYNG3A4HDRo0IDNmzdzzTXXXLT9GHM5sgRszGUgKCiIdevWcezYMQC++eYbqlSpcpatnBYuXMjq1auJi4vjmWeeAeDee++lXLly/Pbbb6xfv55Jkyaxf//+ix73gAED6N27NwCzZs2ia9eurFq1itq1a/PTTz8Vuh1VJTs7+6LHZ4w3WQI25jLRvn175syZA8CHH35Ijx49zmn7Fi1akJyczObNm1m6dCmjR4/Gx8f5K6BWrVp07NgxT/20tDTatGlDw4YNiY6O5rPPPgPg6NGjdOzYkdjYWKKiopg+fToADz/8MBEREcTExDB06FAAnnzySV544QXmzp3LK6+8wjvvvEPr1q2BvD3tsWPHEh8fT0xMDCNHjgRg27ZtXH311QwcOJCGDRuyY0fuydWMufx5dCQsY8zF0717d5566ik6derEmjVruOeee/jhhx8Kvf0XX3xBdHQ069evx+Fw4Ovre8b6AQEBfPrpp5QuXZr9+/fTpEkTunTpwpdffsmVV17p/mMgNTWVAwcO8Omnn7JhwwZEhEOHDuVpq0OHDgwYMIDg4GB3cs7x9ddf89tvv7Fs2TJUlS5durBo0SKqV6/Oxo0bmThxIm+++WahP6cxlwvrARtTRE2dCjVqgI8PpKfD2rUxbNu2jQ8//JAOHToUup3WrVvjcDg4fPgwjzzySKG3U1UeffRRYmJiuP7669m1axd79+4lOjqa+fPnM3z4cH744QdCQ0MpXbo0AQEB3HvvvXzyyScEBgYWej9ff/01X3/9NQ0aNKBhw4Zs2LCB3377DYDw8HCaNGlS6LaMuZxYD9iYImjqVOjf35l4c/TvD+3bd2Ho0KF89913/Pnnn4Vqa+HChVSoUMG9HBkZyerVq8nOznafgi44hqmkpKSwYsUK/P39qVGjBsePH6du3bqsWLGCuXPn8sgjj9CuXTueeOIJli1bxoIFC5g2bRpvvPEG3377baHiU1UeeeQR7rvvvjzl27ZtIygoqFBtGHM5sh6wMUXQY4/lTb7gXP7553t44okniI6OPu+2a9euTVxcHCNHjkRVAfjtt9/c13hzpKamUrFiRfz9/Vm4cCHbt28HYPfu3QQGBnLnnXcydOhQVq5cSVpaGqmpqXTo0IFXXnmFpKSkQsdzww038N5775GWlgbArl272Ldv33l/PmMuF9YDNqYI+v33gst3767KAw88UOC6SZMmMWvWLPfyzz//fNr233nnHf7v//6Pq666isDAQMqXL8/YsWPz1OnVqxedO3cmLi4Oh8NB/fr1AVi7di3Dhg3Dx8cHf39/3nrrLY4cOULXrl05fvw4qsrLL79c6M/arl07fv31V5o2bQo4b86aMmXKWa9RG3O5k5y/gC8XcXFxmpiY6O0wjPGoGjXA1eHMIzwctm271NGY4kBEVqhqnLfjMH+xU9DGFEFjxkD++5gCA53lxpjiwRKwMUVE7udie/WCCROcPV4R578TJjjLzyQxMZEhQ4acdv22bdv44IMPCl0f/hpNKyYmhpYtW7qvBRcFuUfaMuZy49FT0CJyI/Aq4Au8o6rP5VvfFXgayAYygX+p6uIztWmnoE1xFRwc7L4RyVO+++47XnjhBb744otCb1OjRg0SExOpUKECI0eOZPfu3bz99tsXFIeqoqpnvAvbXFx2Crro8di3X0R8gXFAeyAC6CEiEfmqLQBiVdUB3AO846l4jLkcJSUl0aRJE2JiYrj55ps5ePAgAMuXLycmJoamTZsybNgwoqKiAGeCzRkf+vvvv8fhcLjHXz5y5AgPP/wwP/zwAw6Hg5dffjlP/bS0NO6++253b3fmzJmnxNO0aVN27doFQEpKCrfeeivx8fHEx8fz448/usvbtm1Lw4YNue+++wgPD2f//v0FjmxV0AhY5zPS1pmOVatWrRg+fDgJCQnUrVv3nAYvMcaTPPnnZwKQrKpbVPUkMA3omruCqqbpX13wIODyuiPMGA/r3bs3zz//PGvWrCE6OppRo0YBcPfddzN+/HiWLFly2ruFX3jhBcaNG0dSUhI//PADpUqV4rnnnuPaa68lKSmJBx98ME/9p59+mtDQUNauXcuaNWu47rrrTmnzyy+/5KabbgLggQce4MEHH2T58uXMnDmTe++9F4BRo0Zx3XXXsXLlSm6++WZ+z3VL98aNG+nduzerVq1i48aN7hGwkpKSWLFiBYsWLXKPtLV69WrWrVvHjTfe6B5pa/369axZs4YRI0YU+liBc/KKZcuW8corr+QpN8abPJmAqwC5B2/d6SrLQ0RuFpENwBycveBTiEh/EUkUkcSUlBSPBGuMN+Qf7Wrq1L/WpaamcujQIVq2bAlAnz59WLRoEYcOHeLIkSPu2YR69uxZYNvNmjXjoYce4rXXXuPQoUP4+Z35qcP58+czaNAg93LZsmXd71u3bk3FihWZP3++e3/z589n8ODBOBwOunTpwuHDhzly5AiLFy+me/fuANx444152sk9stXpRsA6n5G2Tnesctxyyy0ANGrUiG12G7kpIjyZgKWAslN6uKr6qarWB27CeT341I1UJ6hqnKrGhYWFXdwojfGSnNGutm8HVeerf/+8Sbgghb1v4+GHH+add97h2LFjNGnShA0bNpy1XZGC/tviHogjMjKSJ554AoDs7GyWLFlCUlISSUlJ7Nq1i5CQkDPGl3tkq5wRsHK2T05Opl+/fu6RtqKjo3nkkUd46qmn8PPzY9myZdx6663MmjWLG2+8sVDHIEfJkiUB8PX1JTMz85y2NcZTPJmAdwLVci1XBXafrrKqLgJqi0iF09Uxpjg53WhXjz3mfB8aGkrZsmXd1yz/97//0bJlS8qWLUtISIh7oI1p06YV2P7mzZuJjo5m+PDhxMXFsWHDBkJCQjhy5EiB9du1a8cbb7zhXs65hpqjVKlSvPLKK7z//vscOHDglPo5o181b96cjz76CHD2cvO3k+N0I2Cdz0hbpztWxhRlnhwJazlQR0RqAruA7kCec2UichWwWVVVRBoCJYDCDXBrzGXu1NGu0oGqbN8OVavCQw89xOTJkxkwYADp6enUqlWLiRMnAvDuu+/yj3/8g6CgIFq1akVoaOgp7b/yyissXLgQX19fIiIiaN++PT4+Pvj5+REbG0vfvn1p0KCBu/6IESMYNGgQUVFR+Pr6MnLkSPep2xyVK1emR48ejBs3jtdee41BgwYRExNDZmYmLVq0YPz48YwcOZIePXowffp0WrZsSeXKlQkJCTnlDu/TjYCVnJx8XiNtne5YGVNUefoxpA7AKzgfQ3pPVceIyAAAVR0vIsOB3kAGcAwYZo8hmb+LCxntKi0tzf3c8HPPPceePXt49dVXL3qM5+PEiRP4+vri5+fHkiVLuP/++89pbGjjGfYYUtHj0bGgVXUuMDdf2fhc758HnvdkDMYUVWPGnDrjUWFHu5ozZw7PPvssmZmZhIeHM2nSJI/Fea5+//13br/9drKzsylRosQFPzNsTHFlT8Eb4yX5R7sCX/z9K9OvXwClSpWiTp06tG/f/pQ5fJOSknjyySdJSkri559/pmrVqjRp0oTIyEhatGjB0qVLT7vPwox8dTYvvPAC9evXR0QoVaoU4eHhOBwOatWqRWJiInXq1GHNmjWICMeOHeOpp57i0KFDPPPMM4XeR06cN998M7GxsQQGBuLr60uFChUICAhg6tnuVCuEnBG+cp6Vnj9/Pvfddx+1a9c+5VjmHqXsXCUlJTF37l/9kPHjxzN06FDi4uKoVasWAQEBVKxYkc2bN1OtWjX3c80XQ86d8i5VRWS9iIwVkQEi0vui7cicn5wRaS6XV6NGjdSY4qhUqVLapEkTPX78uH755ZfatGlT/e6777RmzZp56g0fPlyfeuopVVW944479OGHH9asrCxVVd28ebN+8cUXHovxrbfe0nbt2mlqaqoGBQXpoUOHdNKkSaqq2rJlS12+fLmqqgYFBbm36d27t44ePTpPWW7Z2dnu+AuyZMkSjYmJ0Y4dO+rEiRN10KBB7nUZGRlnjTkzM7PA8vDwcE1JSXEvn+lY5o69MPvMLX/Ma9eu1Vq1aumvv/6qzz77rI4YMULHjRunqqojR47UsWPHFqrdsx23/IAsoKSex+9dwO98trPXWY6rtwM415clYFNcBQQEaKdOnVRV9aOPPtKuXbuqqmpMTIzGxcVpgwYNNCoqSitWrKibNm3S5ORkLVOmjNarV0+vv/567d69u/uX97JlyzQ6OlqbNGmiQ4cO1cjISFVVXbhwoXbs2FFVnb/s7777bm3ZsqXWrFlTX331VXcsTz31VIHtVqtWTZOTk1VVT0moLVu21IULF2rdunXV19dXGzVqpKVLl9aoqCht0KCB+vj4aNmyZdXX11dLlCihvr6+2qNHD61Ro4ZWqlRJ/f393esiIyO1Y8eOunfvXq1YsaKKiPr6+urtt9+uZcqU0TZt2mibNm00ODhYAwIC1M/PT0NDQzUmJkZbt26twcHBGh4err6+vlq5cmUtW7asVqpUSfv06aO7d+/Wa6+9Vv39/bV+/fq6aNEiTU5O1ho1aujmzZv1uuuu0+joaL3uuut0+/btqqrq5+enDz74oDZv3lyrVaumERERGhwcrLVq1dLmzZvrihUrtEOHDhoeHq4lS5bU6tWr67XXXqtDhw5VPz8/9fX11bCwMJ02bZrGxMRot27ddM6cOVqpUiW98sortVWrVqqq6u/v7z7Wt956qwYGBmpAQIDWr19fjx49qlu3btUqVapo2bJlNSAgQOPj41VVdd26dRofH6+xsbEaHR2tmzZtyvMz6ty5s+J8DDQJuAN4EhiqqgC1gS+BFcAPQH1X+STgJWAh8KIWgd//xe1lp6CNKSJOnjzJ/PnzKVGiBHfeeScdOnQAoEePHsTHx7Ny5UrGjh1LamoqV111FbNmzSI7O5tVq1bxySefkPvmxMKMlAWwYcMGvvrqK5YtW8aoUaPIyMggMTGRmTNnntLukSNHOHLkCLVr1wbg2LFj7tO3DoeDffv2ERwczBtvvIGqMnToUBo3bswff/zBP/7xD0qVKkX58uU5duwYGzduJDs7mz179hAcHMzw4cOpXLkymzdv5sCBA2zatImUlBSysrJQVRo2bEi7du3YuXMn4JyTODs7myuvvJLBgwfTt29fqlSpQocOHVixYgVZWVk0bNiQO+64g7S0NL755huqVq1KYmIiY8eO5YYbbuDKK6/E19eXgQMH0r59exwOBw888AC9e/dmzZo19OrVK8/p+k2bNjF//nzWrVvHFVdcwfz58xERxo4dS+/evbnyyisJCQlh8+bNrFmzhsmTJzN79mwmTJjAgAED2LRpE3fccQf79u2jatWqdOjQgQEDBvDggw+ycOHCPD+Xr7/+msDAQNLS0jh69CiZmZnuSxG7du0iNDSUWrVqkZ6ezksvvcRbb73FAw88QFJSEomJiVStWjVPe7NnzwbIVlWHqk7PKReRp4AZwD9VtREwFHgz16bXA5NU9f/O/g3+i4jcICJJrleaiGx0vb/gmTNEZKiIbBCRdSKyOudUuoh8JyIX5SYzEYkTkddc70uKyHxX/HeIyDsFDKt8Xjx6E5Yx5swGDnReB87KAihFnz6pdO/+A++//z4DBw7E39+f22+/nZiYGBYvXsyePXvIyspi7969/Prrr1SuXJlSpUoB0LlzZ4ACR8o63eQLHTt2pGTJkpQsWZKKFSuyd+9eFi9eTNeuXU9pV1XJyBBq1Mh5hKoUw4YluWdouvrqVnTuDHv3tkU1mx49eiAi+Pn5uR+T8vf356qrriIjIwM/Pz/27NlDq1ateOedd/D398+zr4MHD7J06VIcDgdHjhzBx8eHO+64g5EjR5KQkMD3339PiRIlGDduHNnZ2Zw4cYI//viDrKwsSpYsyfHjx1m1ahUnTpygX79+pKamUrt2bcqXL8/EiRM5dOgQEydOpHXr1syePZuJEyeyZMkSPvnkEwDuuusu/v3vf7uPVbdu3fDx8WHYsGEsXLiQVq1auds+fvw48+fPJzQ0lK5du3LffffRpUsXAgICmDhxIkFBQaeM3nUmOaOEhYSEkJWVRWZmJqtXr3avv+qqq7j99tu59tprGTx4MKVLl+aZZ55h586d3HLLLdSpU6ewu/oPMAyYkWsQlpK51r+oqpMLHbiLqn4FfAXOxIizt53n8RUR8VXVrHNp1/UUTVsgQVUPi0gozkGcLipXrDnxNgD81TlnAcD0Ajc6jTN9TusBG+MlAwfCW2/lJF+Ao/z3v4245ZbBpKSkEBQUxIcffshnn31GRkYGL774IgEBAVxxxRUcP36cSpUqkZyczLJly/K06zp9WChbt24lLi6Oq6++mi1btjBq1ChU1T1rUm6ff16a9PQgtm/fguYbuWvqVNi0Cf74A1Q3u7aozOOP/0DZsmXdPclGjRpRpkwZ0tLSUFVSUlK45ppraN26NTt37uTPP/9k4cKFlClThizXgSlodK6cPw7atGnD1Vdf7Z6t6c8//+S2227D398fHx8fnnzySerUqUNSUhJbt26latWq1KtXj0WLFuHr68ugQYN4//33iYyMZPXq1accu9z7DgoKYurUqaSkpFCxYkWOHTtG9erVmTNnDps3b2bFihUMHTqUjIwMpk6dSlxcHPPmzaNRo0Zs3brVPXpXWFiYuyd/OqpKZmYmP/74I8eOHePtt9+mRo0a7phGjx7Njh07aNu2Lc8//zzff/89n332GSVLliQ+Pp569eq5n8/O+3FkrYisxtmzBfgvcNyVXL7EORZDhojk/PA7ishQ18YOEflZRNaIyKciUtZV/p2IPC8iy0Rkk4hce7rPJSLbROQJEVkMdBORdiKyRERWisgMEQl21WskIt+LyAoR+UpEKruaeBQYqKqHXccptaA/EETkLdfwxetFZFSu8udE5BfXZ3jBVdYtV296kauslYh8ISIVgSmAw9UDrp27p32G+PN8ztMdD0vAxnjJhAkFlc7g8OF1+Pr6kp6ezlVXXYWPj4971qNy5cq5f3nfdNNNiAjjxo3jyJEjzJkzh/3797No0aJCjZS1b98+Pv30U6ZMmcKvv/5KnTp1qF69Os2bN2fTpk1kZGSQlpbGnDlzAOcIXaqPAIOAwwCkpx9myJAJPPYYZGfntJxzBvNDnn12IBkZGagqfn5+pKSkuE/lZmVlERISQrNmzahYsSLBwcGEhYWRlJREamoqAI0bNyYpKcndRs4IW+CcmWn+/PkkJCTwwAMP0LhxYzZt2sSffzrH8rnuuuuYOnWqO6nmfKacBBoSEkLPnj1ZuXIltWvXJi4ujvLly/Phhx8C8OKLL7pPt+dITU2lSpUq1KpVi5EjR7J9+3ZUlW+++YbAwECaNm3KqFGjKFOmDGXLlmXDhg00b94ch8Phfha6WbNmfPvtt2zatAlwJtuXXnopz35uuOEGUlNTKV26NBkZGbz77rscO3bMvb5x48Y89dRTVKhQAV9fXzIyMggODiYwMJCIiAjuv/9+li9fTkZGBlu3bmXevHngHB64sarGAj+6msoA9onI3cDNQCRwFzC6gK/M+8BwVY0B1gIjc63zU9UE4F/5ygtyXFWbA/OBEcD1qtoQZ4/zIRHxB14HbnOdFn8PGCMiIUCI/vUX3pk8ps5nnmOAliISIyLlcj6j6zPkfMYngBtcx6VL7kZUdR9wL/CD6/S9e9+uURtPiT//51TVgv8DunZwWb3sJixTXPw1AnTOC4VAhZLq5+enlSpV0pSUFF2xYoUGBAQooE2aNNGQkBCtV6+e3n777Vq5cmUNCgrSUqVKaalSpdTf318bNmyoXbp00fLly2uTJk10yJAhWq5cOY2Li9O6devqNddco6rqvhkoR2RkpG7dulVVnTdUhYWFadu2bTUhIUHDw8MVYhRuVnhaoa4rXlHwVwhSqKbwkkKAa11JhSpav359FRFt06aNikjOzUAaEBCgoaGhGhUVpVWqVFF/f3/18/PT0qVLq6+vr1arVs0dl4+Pj/r5+WmDBg20TJky2q1bN926das6HA73TVg5Nz9VrVpVw8LCdO/evTpw4EAtWbKkRkZGaqtWrbRHjx46aNAgjYyMVH9/f23cuLFu2bJFVVVTU1P1jjvu0ICAAC1ZsqSWKVNGZ8+erarOm7BmzJihKSkp2qRJE3fMJUuW1Nq1a+tdd92l0dHRGhoaqqVKldJatWppv379ND4+XiMiIrRUqVJarVo1nTZtmvvmt4YNG2r58uW1YsWKOnToUFXNexPWbbfdpv7+/hoUFKShoZW0VKmbFbYqoFWrRmlkZKQOGTJEs7OztWTJklq3bl0NDQ3VwMBAjYyM1NjYWBUR/eqrr/Shhx5SnNeAc/4geRLn9d5JwECcp4uPAQeBD3H2hCcBH7nqhQK/59q+NrDS9f47oJnrfSWcs+CRq+53QJzr/TYg3PW+E7Af541hScAvwLtAFM6/8HLK1wJfA6WBA3qa3JBvPwOAlcAaIAXnSIx+wGrXPm4BSrjqjge+Af4BlHeVtQK+yP8+935OF3/+z3mml9cT6rm+LAGb4sLXN38CDlJQ9fHJ1Ntuu03nzZunqqpbt25138X84osv6t13362qqqtXr1YfHx9dvny5Jicna4kSJfTbb7/VkydPatOmTd2PvkRERGi1atW0Zs2aGhUVpQEBAfrJJ59ogwYNNCkpqcDYHnnkER07dqwePXpUY2NjdcWKFRoergqPKdyoMFYhSuEBrVjxG61W7aDrMwxWmOJ6f0KrVUtX1bx3TOe8X7Vqlfbs2dOdcK6++motW7asxsbGas2aNTUsLEyPHj2qffr00Y4dO572caLCWrVqlc6ZM8e9/Nlnn+mzzz573u2dPHlShw8frldddZVGRkZqfHy8zp07V1VPfcTpQjz44Gfq7/+s65juU/BREYeOGLFI27dvr6tWrdJy5cppdna23nLLLfrll18W0MaDCmzTU5PWJJw9TXBe++2As6f7reZN1GdLwDmJr0L+/RSQgCu43ncGPiwgpmhgSf5y17odQK3TrMtJjDWBZKBsrs/Y93Sf0VXeGHjK1X75QibgAuPP/znP9LJT0MZ4Sf/++UuOAQ78/Mpz4MAB2rZte8o2ixYt4s477wQgJiaG0NBQevbsScuWLYmMjKR169b4+/tTt25dpk2bRlRUFL/++isZGRmULl0aX19fSpcuTXJycp52888Q9Pnnn/PSSy/RsGFD9ynerKxoRKbi7FAANMPHZz2dO2/l0UezcN5j1BR4BniegIDtPPtsqdN+/qSkJH777TfAObTmb7/9ho+P81dS6dKlOXHiBNOnO+936dat2xnv5i6M/ANidOnShYcffvi823v88cfZs2cP69atY926dXz++eennejiQnzySRcyMnLiXAD4oLqK//3vWiZPnsy///1vBg8ejIhwww038NZbb5GRkQE4T7sfPXqUdu3aAVTIdY2yXO59uMpD1Tl64b8AR+71qpoKHMx1ffcu4PsL/Gg/A81ccwIgIoEiUhfYCISJSFNXub+IRLq2eRYYJyKlXetKi0j+/0mlgaNAqohUAtqf6TOKSG1VXaqqT+Ds0VajcE4Xf6FZAjbGS5o1g7w5pRS+vkm88cZ2Tp48ybhx4wrcLveNQTVq1OCDDz7g9ddfJzo62l3esGFDunfvzquvvoqvry9btmxxT/u3d+9ehg0bRkBAAP369aNz5860a9eOtLQ02rRpQ8OGDdm3bx/t2rVjw4YNfPPNN67RqE5y5ZWB+Po6r7GGh48nOroEhw59xZgxDoYMWUDJkv8FBD+/SQQGtqFy5W9p1aoVJ0+eJCEhgbp165KVlcXJkyd54oknWL9+PS+99BIzZswgMDCQ7t27ux+ladWqlXsu4fT0dNq0aUNMTAxt2rThd9dMFtu3by+wfMaMGURFRREbG0uLFi3c+5s+fToOh4Pp06czadIkBg8eDEDfvn0ZMmQI11xzDbVq1eLjjz8GnFMuDhw4kMjISDp16kSHDh34+OOPSU9P5+233+b11193T3VYqVIlbr/99lN+XjfddBONGjUiMjKSCa4L/1lZWfTt25eoqCiio6Pdk0u89tprREREEBMT455Tefv2ScBgnGc5/w1kAqXYvv1qqlSpQrNmzRg5ciRTpkzhnXfeYcmSJVSqVInIyEjuu+8+KlWqxE8//QTgD6wVkSScvdrcQoAvRGQNzsT6YAFfvT7AWFcdB84e43lT1RSgL/Chq82fcT6DfBK4DXjedcNYEpAzpNdbOJ9LXi4i61yxpudrdzWwCliP8/pxzvXu033Gsa6b09YBi3Cepj7v+M/hENgpaGO8xXlK99RT0OHhqitXrtRq1arpyZMnTzkF3a9fP1V1jqjk6+ury5cv1507d2p4eLgeOHBAMzIytEWLFjpo0CB99dVXtV69evqf//zHvd9Vq1apqnOwDV9fX126dKmqqp44cULHjBmjqqrDhg3T8uXLa3Z2toaGhmr9+vX10KFD2qpVKw0JCdGxY8dqcnKy9unTR2fMmKGxsbEaExOjy5Yt0+zsbJ02bZpGREToyy+/rC1btlQ/Pz9VVZ0zZ476+PioqnOEqPj4ePcp6Nq1a2tISIjGxsZqxYoVtUGDBpqZmal9+vTRRo0auUfcevfdd92DlHTq1KnA8qioKN25c6eqqh48eNC9v9wjUuVe7tOnj952222alZWl69ev19q1a6uq6owZM7R9+/aalZWle/bs0TJlyuiMGTN09erV6nA4zvCz/esU9J9//qmqqunp6RoZGan79+/XxMREvf766931c2KsXLmyHj9+PE9Z+fITFQa5viN/vQ8P/2s/v/zyi3bq1ElPnjypqqr333+/Tp48WVVVAZ0+fboCiVoEfofb66+X9YCN8ZJTpyP8q7xBgwbExsaecgfz/fffT1paGjExMfznP/8hISEBgCpVqvDoo4/SuHFjrr/+evz9I/jf/0J54AHYtasVM2cmEhMTQ7ly5WjTpg3x8fFUq1aNVq1acf/993P11VcTGxvLjBkziImJ4f333yc1NZW9e/fStm1b9uzZQ9euXYmKiqJaNecZumHDhvHZZ5/x4IMPEhUVxdatW93PD/ft25e9e/fSu7dzuGE/P+eQA40aNcKZE0513333UaZMGVSVcuXK4efnx9ixYwHnqdSePZ2zmd51110sXuycNG3JkiUFljdr1oy+ffvy9ttvux9nOpubbroJHx8fIiIi2Lt3LwCLFy92P/97xRVX0Lp160K1ldtrr71GbGwsTZo0YceOHfz222/UqlWLLVu28M9//pMvv/yS0qVLA87LCr169WLKlCnuY3brreCXb8SG/JN2LFiwgBUrVhAfH4/D4WDBggVs2bIFAF9fX2699dZzjtt4ng3EYYyXVK+efzrCNHc5OK/D5li3bh3gfP71dI8V9ezZk/79+/P++5ncfffNZGe3A0qTljaTtWu/Z8IE5wQQ+/fvJy7OOWBQ/fr1eeONNwCYNGkS8+bNY8qUKfj7+1OjRg2OHz9Os2bNiIiIYNQo5+OUDz3kfNLik08+oW/fvnTq1Il69eqxefNmlixZUmBsP/zwA+BMBtVzPiCQkJDA0KHOs6FhYWF06dLFHc+8efN4/fXXmTt37ikDiRT0bHDu8vHjx7N06VLmzJmT5xGgM8k5lQx/PUt9uj8WrrrqKn7//XeOHDlCSEjIadv87rvvmD9/PkuWLCEwMJBWrVpx/PhxypYty+rVq/nqq68YN24cH330Ee+99x5z5sxh0aJFzJ49m6effpr169fTtCls3ep8znr7dggJcT4/3quX89GwnDj79OnDs88+e0oMAQEBF3z93HiG9YCN8ZIxYyD/4EiFnY6wIE8++SQOh4N+/aLIzq6Jc4Cg64DjpKe/5f5lnZ6eXuD2qampVKxYEX9/fxYuXMh2118HLVq04NNPP+XYsWMcOXIkzx8GOerVq0dKSoo7AWdkZLB+/fozxhsSEnLGm5YWL17sfg73mmuucf/hMXXqVJo3b37G8s2bN+d5VnbHjh1n3V9BmjdvzsyZM8nOzmbv3r189913AAQGBtKvXz+GDBnCyZMnAdizZw9TpkzJs31qaiply5YlMDCQDRs2uJ/N3r9/P9nZ2dx66608/fTTrFy5kuzsbHbs2EHr1q35z3/+w6FDh0hLc/5RVreuc47oiROhd2/co4/laNOmDR9//DH79u0D4MCBA+6fnym6rAdsjJfk/BJ97DHnaefq1Z3JN/8v18LKGbnK55Q/q2cBD7J9+39ISAgjKCiI559/Ps/ADs54etG5c2fi4uJwOBzUr++8nyRnTGWHw0F4eDjXXnvqQEclSpTg448/ZsiQIaSmppKZmcm//vUvIiMjT6mbo3Xr1jz33HM4HA73OMfTp09n8eLFZGdnU7VqVfc8x6+99hr33HMPY8eOJSwsjIkTJ56xfNiwYfz222+oKm3atCE2Npbq1aufsr+zufXWW1mwYAFRUVHUrVuXxo0bu4fVHD16NCNGjCAiIoKAgACCgoJ46qm89yXdeOONjB8/npiYGOrVq0eTJk0A53jOd999N9mu0UueffZZsrKyuPPOO0lNTUVVefDBBylTpkyh4oyIiGD06NG0a9eO7Oxs/P39GTduHOHh4YXa3niHnO4US1EVFxenuQedN8bkVaNG/lPbTuHhzl6UOTdpaWkEBwfz559/kpCQwI8//sgVV1zh7bDOmYisUOfoUKaI8OgpaBG5UZyzYCSLyCkP3IlIL9eYnGtE5CcRifVkPMb8HVzsU9t/d506dcLhcHDttdfy+OOPX5bJ1xRNHjsFLSK+wDicM1fsxPnc1mxV/SVXta1AS1U9KCLtgQk4RyQxxpyni31q++8u57qvMRebJ68BJ+AcE3QLgIhMA7riHC8TAFX9KVf9n4G8k1gaY85Lr16WcI0p6jx5CroKznE1c+x0lZ1OP2BeQStEpL9raqnElJSUgqoYY4wxlxVPJuCCHtQr8I4vEWmNMwEPL2i9qk5Q1ThVjQsLC7uIIRpjjDHe4clT0DvJO6h1VWB3/koiEgO8A7RX1T89GI8xxhhTZHiyB7wcqCMiNUWkBM75GGfnriAi1YFPgLtUdZMHYzHGGGOKFI/1gFU1U0QG45zo2Rd4T1XXi8gA1/rxwBM451580zWEXKY9p2aMMebv4LIbiENEUoDzHWOtAs75Hk1edlxOZcfkVHZMTnU5HZNwVbWbaIqQyy4BXwgRSbQe9qnsuJzKjsmp7Jicyo6JuRA2GYMxxhjjBZaAjTHGGC/4uyXgCd4OoIiy43IqOyansmNyKjsm5rz9ra4BG2OMMUXF360HbIwxxhQJloCNMcYYLyg2CbgQcw+LiLzmWr9GRBoWdtvL1QUek20islZEkkQk8dJG7jmFOCb1RWSJiJwQkaHnsu3l6gKPSbH8nsCFzWdeXL8r5iJT1cv+hXOkrc1ALaAEsBqIyFenA87ZlgRoAiwt7LaX4+tCjolr3Taggrc/hxeOSUUgHhgDDD2XbS/H14Uck+L6PTmH43INUNb1vn1x/51ir4v/Ki49YPfcw6p6EsiZezi3rsD76vQzUEZEKhdy28vRhRyT4uqsx0RV96nqciDjXLe9TF3IMSnOCnNcflLVg67F3POZF9fvirnIiksCLszcw6erc67zFl8uLuSYgHPqyK9FZIWI9PdYlJfWhfys/87fkzMpjt8TuLD5zIvrd8VcZJ6cjvBSKszcw6erU+h5iy8zF3JMAJqp6m4RqQh8IyIbVHXRRY3w0ruQn/Xf+XtyJsXxewLnN59583Pd1vy9FZcecGHmHj5dnULNW3wZupBjgqrm/LsP+BTnabXL3YX8rP/O35PTKqbfEzj3+cy76l/zmRfX74q5yIpLAj7r3MOu5d6uO3+bAKmquqeQ216OzvuYiEiQiIQAiEgQ0A5YdymD95AL+Vn/nb8nBSrG3xO4sPnMi+t3xVxkxeIUtBZu7uG5OO/6TQbSgbvPtK0XPsZFdSHHBKgEfCrOOZr9gA9U9ctL/BEuusIcExG5AkgESgPZIvIvnHewHv67fk9Od0xwTsVX7L4ncGHzmRfX3ynm4rOhKI0xxhgvKC6noI0xxpjLiiVgY4wxxgssARtjjDFeYAnYGGOM8QJLwMYYY4wXWAI2ppBEJMs160/Oq4aItBIRFZHOuep9ISKtXO+/c82Ks1pElouIw0vhG2OKGEvAxhTeMVV15Hptc5XvBB47w3a9VDUWeBMY6+kgjTGXB0vAxly41UCqiLQ9S70l2KD8xhgXS8DGFF6pXKefP823bjQw4izb3wjM8khkxpjLTrEYitKYS+SYqjoKWqGqP4gIInJtAaunusZK9gUaejJAY8zlw3rAxlw8Yyj4WnAvoCbwATDukkZkjCmyLAEbc5Go6tdAWSC2gHUZOE9RNxGRqy91bMaYoscSsDEX1xic87+eQlWPAS8CQy9pRMaYIslmQzLGGGO8wHrAxhhjjBdYAjbGGGO8wBKwMcYY4wWWgI0xxhgvsARsjDHGeIElYGOMMcYLLAEbY4wxXvD/qCR0kOCApgcAAAAASUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAeAAAAEWCAYAAAC+H0SRAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAABRMElEQVR4nO3dd3hUVfrA8e+bIZBCKBJgkZIA0gJJBggBXKRY6IKiCIhSBBGBdVd/KCAoWFgLqIC0RRR0xQUVxYaKKEovAUJTkGLoJYAEQk/y/v6YyZiEBAJkmKDv53nmydxzz733nZuBN+fec88RVcUYY4wx15afrwMwxhhj/oosARtjjDE+YAnYGGOM8QFLwMYYY4wPWAI2xhhjfMASsDHGGOMDloCNMcYYH7AEbK5rIpIgIqdFJFlEDorINBEp7IXjTBeRF69i+x9F5Iw7zvRXwzyOsamI7MnLfRpjvMcSsPkzuFNVCwN1gHrAsMvZWFyuxb+FAapaOMNrWZY4ClyDGIwx+YQlYPOnoap7ga+BWiJSXES+FJFEEfnd/b5cel13i3SkiCwBTgGVRKS6iHwnIkdFZIuI3Oeu2wfoCjzlbrl+4S6v4d7PMRHZJCLtLjdmdwt+kIisB06KSAERaefe3zH3/mtkqT9QRNaLSJKIzBKRABEJdn/2GzO0sG+8itNpjPEyS8DmT0NEygOtgbW4vtvTgDCgAnAaGJ9lkweBPkAIkAh8B3wAlAK6ABNFpKaqTgFmAK+6W653iog/8AUwz13/H8AMEal2BaF3AdoAxYBKwP+AfwElgbnAFyJSMEP9+4CWQEUgCuihqieBVsC+DC3sfVcQizHmGrEEbP4M5ojIMWAx8BPwb1U9oqqzVfWUqp4ARgJNsmw3XVU3qWoKroSWoKrTVDVFVdcAs4F7czhmA6Aw8LKqnlPVH4AvcSXTnIxzt2qPiciajOWqultVTwOdgK9U9TtVPQ+MBgKBm7PU36eqR3H9EeC8xPkxxuRDds/J/BncparzMxaISBDwBq7EWtxdHCIiDlVNdS/vzrBJGFDfncjTFQD+m8MxbwR2q2pahrKdQNmLxPmYqk7NpjxjHDe69wOAqqaJyO4s+z2Q4f0p9zbGmOuMJWDzZ/V/QDWgvqoeEBEnrkvTkqFOxqnAdgM/qeodOewv67Rh+4DyIuKXIQlXAH69glgz7nsfEJm+ICIClAf2XuZ+jDH5nF2CNn9WIbju+x4TkRuA4Zeo/yVQVUQeFBF/96tehg5QB3Hdn023AjiJq2OWv4g0Be4EZl5l3B8CbUTkNvd95v8DzgJLc7HtQaCEiBS9yhiMMdeAJWDzZzUG173Tw8By4JuLVXbfJ24OdMbVCj0AvAIUcld5G4hw37+do6rngHa4Oj4dBiYC3VR189UErapbgAeAN937vRPXY1bncrHtZlwduHa447RL08bkY6JqV62MMcaYa81awMYYY4wPWAI2xhhjfMASsDHGGOMDXkvAIvKOiBwSkY05rBcRGSci29zD6tXxVizGGGNMfuPN54Cn4xr6770c1rcCqrhf9YFJ7p8XFRoaquHh4XkToTHG/EWsXr36sKqW9HUc5g9eS8CqulBEwi9SpT3wnrq6YS8XkWIiUkZV919sv+Hh4cTFxeVlqMYY86cnIjsvXctcS768B1yWzEPw7eHiw/gZY4wxfxq+TMCSTVm2DyWLSB8RiRORuMTExKs6qMPhwOl0UqtWLTp27MipU6euan9XYs6cOfz888/X/LjGGGPyD18m4D24xrhNVw7XCEQXUNUpqhqjqjElS17dLYzAwEDi4+PZuHEjBQsWZPLkybnaLiUl5aqOm9HFEnBeHscYY0z+5csE/DnQzd0bugGQdKn7v3ntlltuYdu2bZw8eZKHHnqIevXqUbt2bT777DMApk+fTseOHbnzzjtp3rw5ycnJ9OzZk8jISKKiopg9ezYA8+bNo2HDhtSpU4eOHTuSnJwMuO5XDxo0iNjYWGJjY9m2bRtLly7l888/58knn8TpdLJ9+3aaNm3K008/TZMmTRg7dizff/89tWvXJjIykoceeoizZ8969jd8+HDq1KlDZGQkmzdf1aiHxhhjfMibjyH9D1gGVBORPSLSS0T6ikhfd5W5wA5gG/AW0M9bsWQnJSWFr7/+msjISEaOHMmtt97KqlWrWLBgAU8++SQnT54EYNmyZbz77rv88MMPvPDCCxQtWpQNGzawfv16br31Vg4fPsyLL77I/PnzWbNmDTExMbz++uue4xQpUoSVK1cyYMAA/vWvf3HzzTfTrl07Ro0aRXx8PJUrVwbg2LFj/PTTT/Tv358ePXowa9YsNmzYQEpKCpMmTfLsLzQ0lDVr1vDoo48yevToa3nKjDHG5CGvJWBV7aKqZVTVX1XLqerbqjpZVSe716uq9lfVyqoaqape69q8uN8M9hQIJ038OH3yJFVCw4iJiaFChQr06tWLefPm8fLLL+N0OmnatClnzpxh165dANxxxx3ccMMNAMyfP5/+/ft79lu8eHGWL1/Ozz//zN///necTifvvvsuO3f+0dmwS5cunp/Lli3LMcZOnToBsGXLFipWrEjVqlUB6N69OwsXLvTU69ChAwB169YlISEhD86OMcYYX/jTzwe8uN8Mak/qQzCuzlaBQPyRw6y97980erMrAKrK7NmzqVatWqZtV6xYQXBwsGdZVXFNz0qmsjvuuIP//e9/2R4/Y/2s22aUfpxLTY5RqJBrch6Hw2H3i40x5jr2px+KMnzKUE/yTRfMKcKnDPUst2jRgjfffNOT/NauXZvtvpo3b8748eM9y7///jsNGjRgyZIlbNu2DYBTp07x669/zMk+a9Ysz8+GDRsCEBISwokTJ7I9RvXq1UlISPDs77///S9NmjS5rM9sjDEm//vTJ+AbU3ddsvyZZ57h/PnzREVFUatWLZ555plstxk2bBi///47tWrVIjo6mgULFlCyZEmmT59Oly5diIqKokGDBpk6R509e5b69eszduxY3njjDQA6d+7MqFGjqF27Ntu3b890jICAAKZNm0bHjh2JjIzEz8+Pvn37Yowx5s/lupsPOCYmRi9nJKw9BcIpl3rhADB7HGGUS0nIw8gulD5qV2hoqFePY4wxlyIiq1U1xtdxmD/86VvACX1GcpKgTGUnCSKhz0gfRWSMMcb8BTphNZrYlcW47gXfmLqLfY4KJPQZSaOJXb1+bOulbIwxJid/+kvQxhhj7BJ0fvSnvwRtjDHG5EeWgI0xxhgfsARsjDHG+IAlYGOMMcYHLAEbY4wxPmAJ2BhjjPEBS8DZGDlyJDVr1iQqKgqn08mKFStISUnh6aefpkqVKjidTpxOJyNH/jGYh8PhwOl0UrNmTaKjo3n99ddJS0vzrF+5ciWNGzemWrVqVK9end69e3Pq1CmmT5/OgAED8iz21q1bc+zYMQDGjRtHjRo16Nq1K59//jkvv/xynh3HGGPM1fnTD8RxuZYtW8aXX37JmjVrKFSoEIcPH+bcuXMMGzaMAwcOsGHDBgICAjhx4gSvvfaaZ7vAwEDi4+MBOHToEPfffz9JSUk899xzHDx4kI4dOzJz5kwaNmzomX0ppwkZrsbcuXM97ydOnMjXX39NxYoVAWjXrl2u95OSkkKBAvb1MMYYb7EWcBb79+8nNDTUM+1faGgoxYoV46233uLNN98kICAAcM1oNGLEiGz3UapUKaZMmcL48eNRVSZMmED37t09syGJCPfeey+lS5fOtN0XX3xB/fr1qV27NrfffjsHDx4E4KeffvK0umvXrs2JEyfYv38/jRs3xul0UqtWLRYtWgS4xp8+fPgwffv2ZceOHbRr14433ngjU0s7MTGRe+65h3r16lGvXj2WLFkCwIgRI+jTpw/NmzenW7dueXtijTHGZGIJOIvmzZuze/duqlatSr9+/fjpp5/Ytm0bFSpUICQkJNf7qVSpEmlpaRw6dIiNGzdSt27dS27TqFEjli9fztq1a+ncuTOvvvoqAKNHj2bChAnEx8ezaNEiAgMD+eCDD2jRogXx8fGsW7cOp9OZaV+TJ0/mxhtvZMGCBTz++OOZ1v3zn//k8ccfZ9WqVcyePZvevXt71q1evZrPPvuMDz74INef1RhjzOWza4zA4n4zPGNFH3NUYGzvF9DO5VmwYAGdOnXi6aefzlR/2rRpjB07liNHjrB06VLKly+f7X4vd5jPPXv20KlTJ/bv38+5c+c8l47//ve/88QTT9C1a1c6dOhAuXLlqFevHg899BDnz5/nrrvuuiABX8z8+fP5+eefPcvHjx/3XA5v164dgYGBlxW3McaYy+fVFrCItBSRLSKyTUQGZ7O+uIh8KiLrRWSliNTyZjzZWdxvBrUn9aFc6k78UMql7iTmP30p8OFennvuOcaPH88XX3zBrl27PEmqZ8+exMfHU7RoUVJTU7Pd744dO3A4HJQqVYqaNWuyevXqS8byj3/8gwEDBrBhwwb+85//cObMGQAGDx7M1KlTOX36tGe+4caNG7Nw4ULKli3Lgw8+yHvvvZfrz5yWlsayZcuIj48nPj6evXv3elr3wcHBud6PMcaYK+e1BCwiDmAC0AqIALqISESWak8D8aoaBXQDxnornpyETxlKMKc8y1uAfZwifMpQAOLj46lWrRq9evViwIABnqSYmprKuXPnst1nYmIiffv2ZcCAAYgIAwYM4N1332XFihWeOu+//z4HDhzItF1SUhJly5YF4N133/WUb9++ncjISAYNGkRMTAybN29m586dlCpViocffphevXqxZs2aXH/m5s2bM378eM9yeucxY4wx1443L0HHAttUdQeAiMwE2gM/Z6gTAbwEoKqbRSRcREqr6kEvxpXJjam7Mi0nA/8AjqXupEBUFDfddBNTpkyhaNGiPPPMM9SqVYuQkBACAwPp3r07N954IwCnT5/G6XRy/vx5ChQowIMPPsgTTzwBQOnSpZk5cyYDBw7k0KFD+Pn50bhxYzp06JDp2CNGjKBjx46ULVuWBg0a8NtvvwEwZswYFixYgMPhICIiglatWjFz5kxGjRqFv78/hQsXvqwW8Lhx4+jfvz9RUVGkpKTQuHFjJk+efOUn0RhjzGXz2nSEInIv0FJVe7uXHwTqq+qADHX+DQSo6hMiEgssdddZnWVffYA+ABUqVKi7c+fOPItzT4FwyqVeuL89jjDKpSTk2XGMMcaXbDrC/Meb94Alm7Ks2f5loLiIxONqeK4FUi7YSHWKqsaoakzJkiXzNMiEPiM5SVCmspMEkdBnZA5bGGOMMVfPm5eg9wAZuweXA/ZlrKCqx4GeACIiwG/u1zXTaGJXFoOnF/Q+RwUS+oyk0cSu1zIMY4wxfzHevARdAPgVuA3YC6wC7lfVTRnqFANOqeo5EXkYuEVVLzoCRExMjMbFxXklZmOM+bOyS9D5j9dawKqaIiIDgG8BB/COqm4Skb7u9ZOBGsB7IpKKq3NWL2/FY4wxxuQnXh2IQ1XnAnOzlE3O8H4ZUMWbMRhjjDH5kQ1FaYwxxviAJWBjjDHGBywBG2OMMT5gCdgYY4zxAUvAxhhjjA9YAjbGGGN8wBKwMcYY4wOWgI0xxhgfsARsjDHG+IAlYGOMMcYHLAEbY4wxPmAJ2BhjjPEBS8DGGGOMD1gCNsYYY3zAErAxxhjjA5aAjTHGGB+wBGyMMcb4gFcTsIi0FJEtIrJNRAZns76oiHwhIutEZJOI9PRmPMYYY0x+4bUELCIOYALQCogAuohIRJZq/YGfVTUaaAq8JiIFvRWTMcYYk194swUcC2xT1R2qeg6YCbTPUkeBEBERoDBwFEjxYkzGGGNMvuDNBFwW2J1heY+7LKPxQA1gH7AB+KeqpmXdkYj0EZE4EYlLTEz0VrzGGGPMNePNBCzZlGmW5RZAPHAj4ATGi0iRCzZSnaKqMaoaU7JkybyO0xhjjLnmvJmA9wDlMyyXw9XSzagn8Im6bAN+A6p7MSZjjDEmX/BmAl4FVBGRiu6OVZ2Bz7PU2QXcBiAipYFqwA4vxmSMMcbkCwW8tWNVTRGRAcC3gAN4R1U3iUhf9/rJwAvAdBHZgOuS9SBVPeytmIwxxpj8wmsJGEBV5wJzs5RNzvB+H9DcmzEYY4wx+ZGNhGWMMcb4gCVgY4wxxgcsARtjjDE+YAnYGGOM8QFLwMYYY4wPWAI2xhhjfMASsDHGGOMDloCNMcYYH7AEbIwxxviAJWBjjDHGBywBG2OMMT5gCdgYY4zxAUvAxhhjjA9YAjbGGGN8wBKwMcYY4wOWgI0xxhgfsARsjDHG+IAlYGOMMcYHvJqARaSliGwRkW0iMjib9U+KSLz7tVFEUkXkBm/GZIwxxuQHXkvAIuIAJgCtgAigi4hEZKyjqqNU1amqTmAI8JOqHvVWTMYYY0x+4c0WcCywTVV3qOo5YCbQ/iL1uwD/82I8xhhjTL7hzQRcFtidYXmPu+wCIhIEtARm57C+j4jEiUhcYmJingdqjDHGXGveTMCSTZnmUPdOYElOl59VdYqqxqhqTMmSJfMsQGOMMcZXvJmA9wDlMyyXA/blULczdvnZGGPMX4g3E/AqoIqIVBSRgriS7OdZK4lIUaAJ8JkXYzHGGGPylQLe2rGqpojIAOBbwAG8o6qbRKSve/1kd9W7gXmqetJbsRhjjDH5jajmdFs2f4qJidG4uDhfh2GMMdcVEVmtqjG+jsP8wUbCMsYYY3zAErAxxhjjA5aAjTHGGB+wBGyMMcb4gCVgY4wxxgcsARtjjDE+YAnYGGOM8QFLwMYYY4wPWAI2xhhjfMASsDHGGOMDloCNMcYYH7AEbIwxxviAJWBjjDHGBywBG2OMMT5wRQlYRKqJyFt5HYwxxhjzV3HRBCwiUSIyT0Q2isiLIlJaRGYD3wM/X5sQjTHGmD+fS7WA3wI+AO4BEoE1wA7gJlV9w8uxGWOMMX9al0rAhVR1uqpuUdWxQBowWFXP5GbnItJSRLaIyDYRGZxDnaYiEi8im0Tkp8uM3xhjjLkuFbjE+gARqQ2IezkZiBIRAVDVNTltKCIOYAJwB7AHWCUin6vqzxnqFAMmAi1VdZeIlLriT2KMMcZcRy7VAj4AvA685n5lXB59iW1jgW2qukNVzwEzgfZZ6twPfKKquwBU9dDlhW+MMflL4cKFPe/nzp1LlSpV2LVrFyNGjCAoKIhDhw5lWzcnrVu35tixYxet07RpU+Li4i4onz59OgMGDMh98JdBRAaKyGZ3H6F1ItLNXf6jiMTk0TFiRGSc+30hEZnvvmLaSUSmikhEXhzHVy7aAlbVplex77LA7gzLe4D6WepUBfxF5EcgBBirqu9l3ZGI9AH6AFSoUOEqQjLGmGvj+++/5x//+Afz5s3z/L8VGhrKa6+9xiuvvJLr/cydO9dbIV6U+0qnqGpaNuv64rq6Gauqx0WkKHBXXsegqnFA+l8WtQF/VXW6l2ddzr5ExKGqqXkY3lW7VC/oxhd53XKJfUs2ZZpluQBQF2gDtACeEZGqF2ykOkVVY1Q1pmTJkpc4rDHG+NaiRYt4+OGH+eqrr6hcubKn/KGHHmLWrFkcPXr0gm3ef/99YmNjcTqdPPLII6SmunJFeHg4hw8fBuCFF16gevXq3HHHHXTp0oXRo/+4EPnRRx8RGxtL1apVWbRokad89+7dtGzZEqCWiAxPLxeRJ9yt140i8i93WbiI/CIiE3F1ui0vItPddTaIyOPuzZ8G+qnqcQBVTVLVd7N+JhGZJCJx7j4+z2Uof1lEfhaR9SIy2l3WMUNreqG7rKmIfOm+Pfk+4HS3gCtnbGmLSHMRWSYia0TkIxEp7C5PEJFnRWQx0DE3v7tr6VL3gJ/MpkyBaKAc4LjItnuA8hmWywH7sqlzWFVPAifdJz0a+PUScRljTL509uxZ2rdvz48//kj16tUzrStcuDAPPfQQY8eO5bnnPPmIX375hVmzZrFkyRL8/f3p168fM2bMoFu3bp46cXFxzJ49m7Vr15KSkkKdOnWoW7euZ31KSgorV65k7ty5PPfcc8yfPx+AlStXsnHjRkJDQzcBHUXkK1z/j/fEdVVSgBXuTrC/A9WAnqraT0TqAmVVtRa4+u2ISAgQoqrbc3E6hqrqUXefoO9FJArX//t3A9VVVd19gQCeBVqo6t4MZYDr9qSI9AYGqmpbdyy4f4YCw4DbVfWkiAwCngCed29+RlUb5SLWa+6iLWBVvTPjC3gF8Af2c+nLDauAKiJSUUQKAp2Bz7PU+Qy4RUQKiEgQri/DL1fwOYwxxmdmzIDwcPDzg9RUf8LCbubtt9/Otu5jjz3Gu+++y/Hjxz1l33//PatXr6ZevXo4nU6+//57duzYkWm7xYsX0759ewIDAwkJCeHOO+/MtL5Dhw4A1K1bl4SEBE/5HXfcQYkSJcCVdD8BGrlfn6rqSVVNdpenX9XcqarL3e93AJVE5E0RaQkcx5Wws17NzMl9IrIGWAvUBCLc+zgDTBWRDsApd90lwHQReZiLN+6yauDe7xIRiQe6A2EZ1l/Wpepr6VItYABE5DbgGVwn/d+q+t2ltlHVFBEZAHyL62S+o6qb3PcOUNXJqvqLiHwDrMf1iNNUVd14hZ/FGGOuuRkzoE8fOJWeRvBjy5YPOXnydkqX/jdPP/10pvrFihXj/vvvZ+LEiZ4yVaV79+689NJLOR5H9eI5r1ChQgA4HA5SUlI85ektxYy7IvtbhOlOZjjm7yISjesWYX/gPlV9SEROikglVd2R005EpCIwEKjn3s90IMCdG2KB23A1zAYAt6pqXxGpj+uWZLyIOC/6gTMcCvhOVbtc6vPkN5e6B9xGRJbiOolDVbVZbpJvOlWdq6pVVbWyqo50l01W1ckZ6oxS1QhVraWqY67wcxhjjE8MHZox+bqcPh3E6dNfMmPGjGxbwk888QT/+c9/PInytttu4+OPP/b0kD569Cg7d+7MtE2jRo344osvOHPmDMnJyXz11Ve5iu+7775Lv+csuK5cLgEWAneJSJCIBOO6JLwo67buy7t+qjobVyOsjnvVS8AEESnirlfE3Vk2oyK4kl+SiJQGWrnrFgaKqupc4F+A011eWVVXqOqzwGEy38K8mOXA30XkJvd+grLrS5QfXaoF/AWu6/VHgEFZ/5JS1XZeissYY64Lu3ZlX7537w0sXfoNjRs3JjQ0NNO60NBQ7r77bt54wzWgYEREBC+++CLNmzcnLS0Nf39/JkyYQFjYH1dS69WrR7t27YiOjiYsLIyYmBiKFi16yfgaNWrEgw8+CK5LwC+5exbjbpGudFebqqprRSQ8y+ZlgWkikt5YG+L+OQkojGt8h/PAeVyPp3qo6joRWQtswnUpe4l7VQjwmYgE4PqjIL1j1ygRqeIu+x5YBzS51OdT1UQR6QH8T0QKuYuHcR30JZKLXdYQkYt+eFW95iNXxcTEaHbPuxljjC+Eh0OWxioAYWGQ4VZsnkhOTqZw4cKcOnWKxo0bM2XKFOrUqXPpDQERWa2qefJ8rskbl2oB/5Y+SIYxxpgLjRyZ9R4wBAW5yvNanz59+Pnnnzlz5gzdu3fPdfI1+dOlEvAc3Nf8RWS2qt7j9YiMMeY60rWr6+fQoa7L0RUquJJvenle+uCDD/J+p8ZnLpWAM970reTNQIwx5nrVtat3Eq75c7vUWNCaw3tjjDHGXIVLtYCjRST9wetA93vcy6qqRbwanTHGGPMndanJGC5nNBJjjDHG5NKlLkEbY4wxxgssARtjjDE+YAnYGGOM8QFLwMYYY4wPWAI2xhhjfMASsDHGGOMDloCNMcYYH7AEbIwxxviAJWBjjDHGB7yagEWkpYhsEZFtIjI4m/VNRSRJROLdr2e9GY8xxhiTX1xqLOgrJiIOYAJwB7AHWCUin6vqz1mqLlLVtt6KwxhjjMmPvNkCjgW2qeoOVT0HzATae/F4xhhjzHXDmwm4LLA7w/Ied1lWDUVknYh8LSI1s9uRiPQRkTgRiUtMTPRGrMYYY8w15c0ELNmUZZ1TeA0QpqrRwJvAnOx2pKpTVDVGVWNKliyZt1EaY4wxPuDNBLwHKJ9huRywL2MFVT2uqsnu93MBfxEJ9WJMxhhjTL7gzQS8CqgiIhVFpCDQGfg8YwUR+ZuIiPt9rDueI16MyRhjjMkXvNYLWlVTRGQA8C3gAN5R1U0i0te9fjJwL/CoiKQAp4HOqpr1MrUxxhjzpyPXW76LiYnRuLg4X4dhjDHXFRFZraoxvo7D/MFGwjLGGGN8wBKwMcYY4wOWgI25BBHhwQcf9CynpKRQsmRJ2rZ1DeA2ffp0BgwYcMF24eHhREZGEh0dTfPmzTlw4AAAycnJPPLII1SuXJmaNWvSuHFjVqxYAUDhwoXzLO7Jkyfz3nvvAbB582acTie1a9dm+/bt3HzzzXl2HGPMlbEEbMwlBAcHs3HjRk6fPg3Ad999R9my2Y0pc6EFCxawbt06YmJi+Pe//w1A7969ueGGG9i6dSubNm1i+vTpHD58OM/j7tu3L926dQNgzpw5tG/fnrVr11K5cmWWLl2a6/2oKmlpaXkenzF/dZaAjcmFVq1a8dVXXwHwv//9jy5dulzW9o0bN2bbtm1s376dFStW8OKLL+Ln5/rnV6lSJdq0aZOpfnJyMrfddht16tQhMjKSzz77DICTJ0/Spk0boqOjqVWrFrNmzQJg8ODBREREEBUVxcCBAwEYMWIEo0ePZu7cuYwZM4apU6fSrFkzIHNLe9SoUdSrV4+oqCiGDx8OQEJCAjVq1KBfv37UqVOH3bszDmpnjMkLXnsMyZg/k86dO/P888/Ttm1b1q9fz0MPPcSiRYtyvf2XX35JZGQkmzZtwul04nA4Llo/ICCATz/9lCJFinD48GEaNGhAu3bt+Oabb7jxxhs9fwwkJSVx9OhRPv30UzZv3oyIcOzYsUz7at26NX379qVw4cKe5Jxu3rx5bN26lZUrV6KqtGvXjoULF1KhQgW2bNnCtGnTmDhxYq4/pzEm96wFbEwuREVFkZCQwP/+9z9at26d6+2aNWuG0+nk+PHjDBkyJNfbqSpPP/00UVFR3H777ezdu5eDBw8SGRnJ/PnzGTRoEIsWLaJo0aIUKVKEgIAAevfuzSeffEJQUFCujzNv3jzmzZtH7dq1qVOnDps3b2br1q0AhIWF0aBBg1zvyxhzeawFbEw2FvebQfiUodyYugt1L7dr146BAwfy448/cuRI7gZsW7BgAaGhf4yuWrNmTdatW0daWprnEnR2ZsyYQWJiIqtXr8bf35/w8HDOnDlD1apVWb16NXPnzmXIkCE0b96cZ599lpUrV/L9998zc+ZMxo8fzw8//JCr+FSVIUOG8Mgjj2QqT0hIIDg4OFf7MMZcGWsBG5PF4n4zqD2pD+VSd+KHIii1J/Wh1rZiPPvss0RGRl7xvitXrkxMTAzDhw8nfRCcrVu3eu7xpktKSqJUqVL4+/uzYMECdu7cCcC+ffsICgrigQceYODAgaxZs4bk5GSSkpJo3bo1Y8aMIT4+PtfxtGjRgnfeeYfk5GQA9u7dy6FDh6748xljcs9awMZkET5lKMGcylQWzCliP3idDu8lZLvN9OnTmTNnjmd5+fLlOe5/6tSp/N///R833XQTQUFBlChRglGjRmWq07VrV+68805iYmJwOp1Ur14dgA0bNvDkk0/i5+eHv78/kyZN4sSJE7Rv354zZ86gqrzxxhu5/qzNmzfnl19+oWHDhoCrc9b7779/yXvUxpirZ0NRGpNFmvjhd8HMmZCG4Kf2OI65PtlQlPmPXYI2Jot9jgqXVW6MMVfCErAxWST0GclJMvckPkkQCX1G+igiY8yfkSVgY7JoNLErax+dwh5HGGkIexxhrH10Co0mdvV1aMaYPxG7B2yMMX8Bdg84/7EWsDGXkN0ECRknOvCmd955h8jISKKioqhVqxafffYZ06dPv2AozMOHD1OyZEnOnj3L+fPnGTx4MFWqVKFWrVrExsby9ddfez1WY8zlsceQjLkCffv29er+VZXdu3czcuRI1qxZQ9GiRUlOTiYxMZESJUowcOBATp065Rn16uOPP6Zdu3YUKlSIwYMHs3//fjZu3EihQoU4ePAgP/30k1fjNcZcPmsBG3MF0ic6AGjatCmDBg0iNjaWqlWresaITk1N5cknn/RMdPCf//wHyHmihawTIPz222+EhIR4WuCFCxemYsWKFClShMaNG/PFF1944pk5cyZdunTh1KlTvPXWW7z55psUKlQIgNKlS3Pfffdds3NjjMkdryZgEWkpIltEZJuIDL5IvXoikioi93ozHmO8JSUlhZUrVzJmzBiee+45AN5++22KFi3KqlWrWLVqFW+99Ra//fabZ6KFNWvWsGDBAv7v//7PMyrWli1b6NatG2vXrqVRo0aULl2aihUr0rNnz0wJt0uXLsycORNwjY7166+/0qxZM7Zt20aFChUoUqTItT8JxpjL4rUELCIOYALQCogAuohIRA71XgG+9VYsxlyuxf1msKdAOGnih548xeJ+My5av0OHDgDUrVuXhIQEwDXRwXvvvYfT6aR+/focOXKErVu35jjRAmSeAMHhcPDNN9/w8ccfU7VqVR5//HFGjBgBQNu2bVm8eDHHjx/nww8/5N5777XRq4y5znjzHnAssE1VdwCIyEygPfBzlnr/AGYD9bwYizG5lj4WdPpwlALUntSHxZDjo0jpl3sdDgcpKSmA6z7um2++SYsWLTLVnT59erYTLQAXTIAgIsTGxhIbG8sdd9xBz549GTFiBIGBgbRs2ZJPP/2UmTNneoafvOmmm9i1axcnTpwgJCQkr06JMcYLvHkJuiyQcRbvPe4yDxEpC9wNTL7YjkSkj4jEiUhcYmJingdqTEY5jQUdPmXoZe2nRYsWTJo0ifPnzwPw66+/cvLkyRwnWshq3759rFmzxrMcHx9PWFiYZ7lLly68/vrrHDx40NNqDgoKolevXjz22GOcO3cOgP379/P+++9fVuzGGO/zZgtYsinL+tDxGGCQqqaKZFfdvZHqFGAKuJ4DzqsAjcnOjam7Mi2fAsoBpO6EcuV44okncrWf3r17k5CQQJ06dVBVSpYsyZw5c3KcaCGr8+fPM3DgQPbt20dAQAAlS5Zk8uQ//lZt3rw53bt3p1evXmT89/Piiy8ybNgwIiIiCAgIIDg4mOeff/5yT4Mxxsu8NhCHiDQERqhqC/fyEABVfSlDnd/4I1GH4vq/ro+qzslpvzYQh/G2PQXCKZd6Yat0jyOMcikJ1z4gY/KADcSR/3jzEvQqoIqIVBSRgkBn4POMFVS1oqqGq2o48DHQ72LJ15hrwcaCNsZcC15LwKqaAgzA1bv5F+BDVd0kIn1FxLujGBhzFWwsaGPMtWBjQRtjzF+AXYLOf2wkLGOMMcYHLAEbY4wxPmAJ2BhjjPEBS8DGGGOMD1gCNsYYY3zAErAxxhjjA5aAjTHGGB+wBGyMMcb4gCVgY4wxxgcsARtjjDE+YAnYGGOM8QFLwMYYY4wPWAI2xhhjfMASsDHGGOMDloCNMcYYH7AEbIwxxviAJWBjrmOFCxe+6n3ExcXx2GOP5bg+ISGBDz74INf1AcLDw4mMjCQqKoomTZqwc+fOq44zr0yePJn33nvP12EYg6iq93Yu0hIYCziAqar6cpb17YEXgDQgBfiXqi6+2D5jYmI0Li7OSxEbc30pXLgwycnJXj3Gjz/+yOjRo/nyyy9zvU14eDhxcXGEhoYyfPhw9u3bx1tvvXVVcagqqoqfn7UbroSIrFbVGF/HYf7gtW+yiDiACUArIALoIiIRWap9D0SrqhN4CJjqrXiM+auIj4+nQYMGREVFcffdd/P7778DsGrVKqKiomjYsCFPPvkktWrVAlwJtm3btgD89NNPOJ1OnE4ntWvX5sSJEwwePJhFixbhdDp54403MtVPTk6mZ8+entbu7NmzL4inYcOG7N27F4DExETuuece6tWrR7169ViyZImn/I477qBOnTo88sgjhIWFcfjwYRISEqhRowb9+vWjTp067N69m1GjRlGvXj2ioqIYPnw4ACdPnqRNmzZER0dTq1YtZs2aBcDgwYOJiIggKiqKgQMHAjBixAhGjx590XPVtGlTBg0aRGxsLFWrVmXRokV5/4syf3ne/FMyFtimqjtU9RwwE2ifsYKqJusfTfBgwHvNcWP+Irp168Yrr7zC+vXriYyM5LnnngOgZ8+eTJ48mWXLluFwOLLddvTo0UyYMIH4+HgWLVpEYGAgL7/8Mrfccgvx8fE8/vjjmeq/8MILFC1alA0bNrB+/XpuvfXWC/b5zTffcNdddwHwz3/+k8cff5xVq1Yxe/ZsevfuDcBzzz3Hrbfeypo1a7j77rvZtWuXZ/stW7bQrVs31q5dy5YtW9i6dSsrV64kPj6e1atXs3DhQr755htuvPFG1q1bx8aNG2nZsiVHjx7l008/ZdOmTaxfv55hw4bl+lwBpKSksHLlSsaMGZOp3Ji84s0EXBbYnWF5j7ssExG5W0Q2A1/hagVfQET6iEiciMQlJiZ6JVhjrheL+81gT4Fw0sQPPXmKxf1meNYlJSVx7NgxmjRpAkD37t1ZuHAhx44d48SJE9x8880A3H///dnu++9//ztPPPEE48aN49ixYxQoUOCiscyfP5/+/ft7losXL+5536xZM0qVKsX8+fM9x5s/fz4DBgzA6XTSrl07jh8/zokTJ1i8eDGdO3cGoGXLlpn2ExYWRoMGDQCYN28e8+bNo3bt2tSpU4fNmzezdetWIiMjmT9/PoMGDWLRokUULVqUIkWKEBAQQO/evfnkk08ICgrKFHtO5ypdhw4dAKhbty4JCQkXPQ/GXAlvJmDJpuyCFq6qfqqq1YG7cN0PvnAj1SmqGqOqMSVLlszbKI25jizuN4Pak/pQLnUnfiiCUntSn0xJODu57esxePBgpk6dyunTp2nQoAGbN2++5H5FsvunDgsWLGDnzp3UrFmTZ599FoC0tDSWLVtGfHw88fHx7N27l5CQkIvGFxwcnOl4Q4YM8Wy/bds2evXqRdWqVVm9ejWRkZEMGTKE559/ngIFCrBy5Uruuece5syZQ8uWLXN1DtIVKlQIAIfDQUpKymVta0xueDMB7wHKZ1guB+zLqbKqLgQqi0ioF2My5roWPmUowZzKVBbMKcKnDAWgaNGiFC9e3HPP8r///S9NmjShePHihISEsHz5cgBmzpyZ7f63b99OZGQkgwYNIiYmhs2bNxMSEsKJEyeyrd+8eXPGjx/vWU6/h5ouMDCQMWPG8N5773H06NEL6sfHxwPQqFEjPvzwQ8DVys26n3QtWrTgnXfe8XQ827t3L4cOHWLfvn0EBQXxwAMPMHDgQNasWUNycjJJSUm0bt2aMWPGeI6VLqdzZcy1cvHrS1dnFVBFRCoCe4HOQKbrXiJyE7BdVVVE6gAFgSNejMmY69qNqbsyLZ/C9ZctqTuhXDmeeOIJ3n33Xfr27cupU6eoVKkS06ZNA+Dtt9/m4YcfJjg4mKZNm1K0aNEL9j9mzBgWLFiAw+EgIiKCVq1a4efnR4ECBYiOjqZHjx7Url3bU3/YsGH079+fWrVq4XA4GD58uOfSbboyZcrQpUsXJkyYwLhx4+jfvz9RUVGkpKTQuHFjJk+ezPDhw+nSpQuzZs2iSZMmlClThpCQkAt6eDdv3pxffvmFhg0bAq5e4O+//z7btm3jySefxM/PD39/fyZNmsSJEydo3749Z86cQVV54403Lvi8OZ0rY64Fbz+G1BoYg+sxpHdUdaSI9AVQ1ckiMgjoBpwHTgNP2mNIxuRsT4FwyqVe+EztHkcY5VISLrptcnKy57nhl19+mf379zN27FhvhAm4Lt1GRkaSkpJCxYoV+e9//0uxYsWyrXv27FkcDgcFChRg2bJlPProoxe0WNNNnz6duLi4TC3pKxUeHk5ISIinU9rEiRM998nzUnx8PPv27aN169aesq+//ppnnnmGkydPoqq0bduW0aNHM2LECAoXLuzptX21br75ZpYuXYqIrAYWAK2BucB24JSq2kPRPuLNFjCqOhfXLzpj2eQM718BXvFmDMb8mST0GUnxSX0yXYY+SRAJfUa6WsIX8dVXX/HSSy+RkpJCWFgY06dP92qsgYGBniTavXt3JkyYwNChQ7Otu2vXLu677z7S0tIoWLDgVT8zfDkWLFhAaOjl3flKSUm5ZAe1jOLj44mLi/Mk4I0bNzJgwAC++uorqlevTkpKClOmTLmsGHJr6dKlGRcfAUqq6tnL3Y+IFFBVuxmeh+yJdmOuI40mdmXto1PY4wgjDWGPI4zHY9vwyE//JioqCqfTSatWrRgyZEim7eLj4xkxYgTx8fEsX76ccuXK0aBBA2rWrEnjxo1ZsWKFV+PO+CzwypUrufnmm6lduzY333wzW7ZsoUqVKvzzn/+kcuXKlChRgvvvv5+nnnrKs/20adOoWrUqTZo08Tw7DLBz505uu+02oqKiuO222zyPL/Xo0YNHH32UZs2aUalSJX766SceeughatSoQY8ePS4a68X2+cQTT9CsWTMGDRrE9u3badmyJXXr1uWWW27xdFj76KOPqFWrFtHR0TRu3Jhz587x7LPPMmvWLJxOJ7NmzeLVV19l6NChVK9eHYACBQrQr1+/C2J56623qFevHtHR0dxzzz2cOnUq22MAbNq0idjYWJxOJ1FRUWzduhXINFraTbge91whIp1EZISIDAQQkcoi8o2IrBaRRSJS3V0+XUReF5EFWGMp76WPLnO9vOrWravGGJelS5dqgwYN9MyZM6qqmpiYqD/++KNWrFgxU71Bgwbp888/r6qqnTp10sGDB2tqaqqqqm7fvl2//PLLPI8tODhYVVVTUlL03nvv1a+//lpVVZOSkvT8+fOqqvrdd99phw4dVFV12rRpWrFiRT127JiePn1aK1SooLt27dJ9+/Zp+fLl9dChQ3r27Fm9+eabtX///qqq2rZtW50+fbqqqr799tvavn17VVXt3r27durUSdPS0nTOnDkaEhKi69ev19TUVK1Tp46uXbtWVVXDwsK0Vq1aGh0drbGxsZfcZ5s2bTQlJUVVVW+99Vb99ddfVVV1+fLl2qxZM1VVrVWrlu7Zs0dVVX///XfPZ0uPWVW1du3aGh8fn+15Gz58uI4aNUpVVQ8fPuwpHzp0qI4bNy7HYwwYMEDff/99VVU9e/asnjp1KtPvAYgDktX9fykwAhjofv89UMX9vj7wg/v9dOBLwKHX6P/4v9LLq5egjTHetX//fkJDQz2PzISGhtKkSROKFSvGihUrqF+/PgAffvgh3377Ldu3b2fFihXMmDHDM6RjpUqVqFSpUp7EM2MGDB0Ku3aB6mnCwpwkJSVQt25d7rjjDsD1/G337t3ZunUrIsL58+c92992222ezmERERHs3LmTw4cP07RpU9IfQezUqRO//vorAMuWLeOTTz4B4MEHH8zUar7zzjsRESIjIyldujSRkZEA1KxZk4SEBJxOJ3DhJeiL7bNjx444HA6Sk5NZunQpHTt29Kw7e9Z1Vffvf/87PXr04L777rugQ9rl2rhxI8OGDePYsWMkJyfTokWLHI/RsGFDRo4cyZ49e+jQoQNVqlTJ1TFEpDBwM/BRhkfKCmWo8pGqpl7VBzHZskvQxlzHmjdvzu7du6latSr9+vXjp59+AqBLly6eR42WL19OiRIlqFKlCps2bcLpdOY4ElZGDocDp9NJdHQ0derUyXov0bM+/dWp08v06QM7d4Kr8RTI4cPxjBq1k3PnztG+vWsgvGeeeYZmzZqxceNGRo4cyb59fzydmP6HRPr+hwwZwuOPP86cOXMoWrQoTqeTV199lf3793vqvf7661SvXh2n08mxY8c8Ey38+9//Ji4uDj8/v0z79fPzy/a53uTkZB555BF+//13z6XdlStXIiIEBgayYsUKgoODOXv2LG3btiUlJYUhQ4YQExPDBx98wC+//AK4Jnt48cUX2b17N06nkyNHMj/YMXnyZAIDA1m9ejWbN2/2DPu5ffv2CzqA9ejRg/Hjx7NhwwaGDx/OmTNncDgcLF++nG3btjFs2DAqV65MYmIi999/P59//jmBgYG0aNGCH3744ZK/Y6AFcCtwTFWdGV413OurAZc9frSItBCRePcrWUS2uN9fdYcvERkoIptFZKOIrBORbu7yH0UkT8a6FpEYERnnfl9IROa74+8kIlOzGVb5ilgCNuY6k3EkrGPFajG2wf8xZcoUSpYsSadOnZg+fTqdO3fm448/Ji0tjZkzZ9KlS5fLPk56J6p169bx0ksvXXBfOX19+mvFisGcyvyIMqdOwciRRRk3bhxz587l/PnzJCUlUbasa1C8NWvWULx4cdLS0rKN4YUXXmDp0qUEBgZSv359Vq1aRcWKFSlTpgzgesTp/fffZ+XKlTz55JO0bNky/fLqZevduzc33HADrVu3ZsiQIUyfPp2PP/6YRo0a4XA4PFcT1q5di6pSr149/Pz8mDp1KjVq1GDdunWA61nq+vXr8/zzzxMaGsru3bszPUv98MMPM2nSJP79738zdepU2rdvz+rVq/nss88u+CPnxIkTlClThvPnzzNjxgzPeZ89ezY7duxg3bp1pKamMmzYMHbs2EGlSpV47LHHaNeuHevXr8/Nx/5WVT8HfhORjgDiEu1evwX46XLPpap+m57McV367upe7pZexz1fwGVxP0VzBxCrqrWAxmQ/6NNVUdU4VU2f8qs24O+Of5aq9lbVny8j5pw/p6+vgV/uy+4Bm7+yRY++r8kEqboameoHGoloxeLlPPcu27Ztq3v37tUSJUroDz/8oOXKldPdu3erquq2bds0ICBAV6xYccljpd87VFX98MMPPfdCZ8+erSEhIQpowYIFPeUwXOFWBX+FmxUcCk6FKdqtWzdP/bCwMPX399fAwECtWrWqiogmJCRoeHi4BgQEaFBQkBYrVkwDAwN1wYIFqqpatmxZBbRQoUIaEhKihQsX1rZt22rBggW1Xr16Wrx4cQ0JCdGIiAidM2eOdu/eXWvUqKEPPPCARkVFqZ+fn1aoUEEjIiI0IiJCa9SoodHR0ern56fly5fXatWqaZEiRTQlJUXHjx+vwcHBGhAQoEWLFtWdO3dqQECAlitXTsePH6+BgYHq5+enhQoV0oiICA0ODtawsDCtUqWKVqxYUf38/NTf31+LFCmiTqdTa9Soof7+/hocHKxBQUEaGxuro0aN0uHDh2uBAgW0QIECGhQUpAMHDtTg4GDPPeBXX31VK1SooP7+/hoWFqYDBgzQe+65R0VEK1asqAEBAVqlShXt3r27Fi9eXEeOHKkRERFasmRJLVKkiNaoUUMnT56c8R7wbiAVWAe8jOse8CrgXqAisAM4434tcW1CPPCu+70TWA6sBz4FirvLf8TVQWsl8Ctwi2b4P9u9Psb9PgF4FliMa2yI5sAyYA3wEVDYXa8ursS/GvgWKOMu3wVU1mxyQ5bjTMKV+DcBz2Wo8zLws/szjHaXdQQ2us/LQndZU1z3vksB24Ak97monOU4OcWf6XNmF6+6/hX7PqlezssSsPkr2+0I8yRfBQ0C/RV0tyNMu3Xrpk2aNPF09pkwYYJGR0drkyZNMu2jZMmS+tBDD2laWpqqqv766686Z86cC47l5+en0dHRnuQUFxenGzZs0IoVK+qqVavUz89PIyIi1OFwaFRUlBYqdKtCGYUvFOop/E2hqoaFqdasWVMDAgJU1dUhLD3xTpgwQdu0aaOqqk899ZQ2bNhQT548qTfffLMWLVpUz507p6tWrVIR0ebNm+vx48e1VKlSWqRIEU1ISNBixYrpkCFD9L///a+qujokValSRZOTk7Vq1arat29fPX/+vO7bt0/r1q2rW7du1UqVKumAAQP0yJEjWrVqVU1KStLPPvtMW7durarZd3AKCAjQNm3a6Pnz5/XLL7/UNm3aaGJiolauXFmbNGmiL7/8sj7wwAN6yy23aHJysh47dkyfffZZLVGihKalpWlYWJiOGDFCVTN3ssr4XvWPP3q+/fZbffjhhzUtLU1TU1O1TZs2+tNPP+lvv/2mgC5btizT76pYsWJ64MAB/c9//qMvvPCCqqqeOXNG69atqzt27NC5c+cqkAwEqStB3OD+Od2dgG/A1dpNHxuimPvnCP7oqLUeaOJ+/zwwRv9IfK+537cG5uvFE/BT7vehwEIg2L08yJ20/IGluB6XAugEvAOEAL9rDrkhy3HSP5/DXR51kc+4ASibpawp8GXW9xmPk1P8WT/nxV7WCcuY60jWkbAU6A4cS91J0vz5FCpUiI8//piEhATefPNNtm3bxmuvvUbnzp35+eefqVGjBhUqVODIkSPcdNNNnDlzht9//50aNWrw5ZdfsnNnIX79dTw7dyYCwvHj/pQo4c/jjz9Ot27dKF68DklJg6lXbzqgJCf74+/vz7fffkvz5j3YtKkmaWltgVeBg0AqN9xwJ4cPH8fhcPDRRx/x8ccfs3v3bgoWLEhERASzZs0iNjaWzZs3c/r0aerUqcORI0c4fvw4Bw8epEePHqgqy5YtY+7cuYSEhFCwYEGKFy+OqjJhwgTOnTtH3759KV++PGfOnKFr167s2rWLadOmMXv2bAoWLEhiYiLNmzfn6NGjfPjhh57tH3/8cUqVKuV5rvdinahUlalTp7Jw4UJuv/129u7dS6lSpbjpppt4/fXXOXHiBE6nk+DgYM6dO0daWhq9e/fm1KlTOU6AkZ2Mk04A7N+fzN13b+Xo0QqAsH17A9zzU3jiSt9u/fr1fPzxx4Crw9vWrVuZP38+wGFVPeWufzTLIY/javlOFZGvcLX+PESkKK7klH45+l1cLb50n7h/rgbCL/HxZrl/NsA1Ve0Sd+evgrhak9WAWsB37nIHsB/Xpebc3l+4T0T64Brrooz7OD/n8BmXANNF5MMMnyM3coo/6+fMkd0DNuY6ss9RIdOyH66mwtd+Fbj55puZOHGip0evw+Hg/PnzpKSkEBQUxPr16xk6dCjx8fEMGzaMRYsW4e/vz549e1i+fDkLF25mwQJXJyr4J1CQAwe+JC3tRv7xj3+wefOvLFkym6NHFwCJpHeyKly4NGfOnKFMGSUiAipUSAPOIxJEq1YP0qxZVc+Qkv379+fWW2/1jEC1evVqdu7cSZcuXShQoABPP/00a9eupU2bNoBrwItevXrhcDho3LgxnTp1AiA1NZXFixdz5swZSpcuzbPPPuv5LCEhIcTHx5Oamsorr7zCihUrCAgI4MCBA+zYsYO77rqLwYMHU758efz9/SlWrBibN29m3rx5pKWlZduJKi0tjUOHDjFjxgyOHTtG1apV6dy5M6VLlyYtLY2wsDDeeOMNoqOjKV26NB06dODnn39m//79nud3e/bs6fm9paamMnjwYMaNG8fo0aOJjY3l66+/Blyjc506dcoz6cSTT8aTnLyNo0d7ebbv08fV4xxgx44dOBwOSpUqhary5ptveu7Ljx07ljVr1qQnaD8RWSEia0XkFhGZiytpoK4BNmKB2bgmxvnmMr+a6QN7pHLpAZ5Oun8K8J3+0fErQlV7ucs3ZSiPVNXmqnocOCkiF+2y7x7+eCBwm6pG4ZppLyCnz6iqfYFhuOYuiBeRErn8zDnFn/Vz5sgSsDHXkYQ+I/mRW9hDWdIQTgM3EUytAoc5evSo51GfjBYuXMgDDzwAQFRUFFFRUYBrQIwmTZpwww034O/vT2JiR/7oHDwfOMvp05WIj1/tHkKyCK5bhYm4bo0Jp04t4PBh19CYFSpU4Pfff+HRR1+lZcti+Puf57vvxjF79mwARITy5cvz8ccfc+zYMUJDQ6lbty7Fixdn/PjxnDt3jtOnT3P8+HFPMgLXRA1paWmkpqaSnJzMgQMHOHfuHJ999hmpqans3LmTkSNH4ufnR5kyZbj77rvx8/MjMDCQTz75hCNHjhAcHMzBgwfZsWMHX331FUWKFKFLly507tyZ1NRU3n77bVJTUxk+fDjbtm2jfv36PPjgg/j7+7N7925UlUOHDpGUlESxYsX429/+Rv369dnp+muFxMREbrnlFvbu3UvXrl1Zs2YNhw4dYs2aNbRu3ZobbriBjRs3ej7TN998w/79++nXrx8DBw7kiy++yDThRbNmzTyTTgwdCqdO7QUOedafOuV63CsxMZG+ffsyYMAARIQWLVowadIkz6Nd1atX5x//+AfNmzfH/Uvbqqq1cSW41sA59++mMFBUXaMX/gvX/V4PVU0CfheRW9xFD3IFnbOyWA783T0nACISJCJVcV0mLikiDd3l/iJS073NS8AEESniXlfE3dLNqAiu5JckIqWBVhf7jCJSWVVXqOqzwGEyTyJ0JfHn3qWuUee3l90DNn9lWTthBYMmE6RfPzRFGzVqpGPHjlVV1d9++01r1qypqqrt27fXH374wbOP2rVr66pVq/STTz7Rbt26ecphrEJ/965LKPgpBCtEa1RUlMKXCg8ojFGorIC7w5VotWrVtGjRohoUFKQiov7+/tqqVSu9/fbbtXr16hoUFKT+/v7qcDi0ePHiWqZMGRURfeqpp7RNmzY6Z84cLViwoAJatGhRbdWqlYqI1q9fX5966ikFVEQ0JiZGy5Ytqw6HQ0uUKKEOh0M7deqkgYGB6nA4NCAgQKOjo7V8+fJarlw57dGjh1arVk0LFCigIqI33HCDRkZG6o033qhVqlRRh8OhBQsW1ODgYB05cqT27t1bCxUqpCKiIqKhoaF65swZBdTf319r1qypZcuW1cDAQK1Ro4ZWr15dQ0NDtXHjxhoUFKQFChTQQoUK6U033aTVq1fXokWLevZXo0YN/eijj/Tpp5/WwMBATUpKyvYecFhYmCYmJuqYMWPcnd0CFAIVXlT4zX3eiysU0oCAAL3zzjs1NTVVx44dqzVq1NCSJUtq0aJFtWbNmlqtWjV9+OGHde3atQqkuF+ncd0jSAD+h+se8ABc94hP45oQp4e6Ws3ngO+AFUAP/uiENYfMnbDS772GAgl68XvAoRnW3YqrI9h696udu9yJ6/7qOlwdqR52lwvwFK4kvRFYCzyQzXGmA7/gav1+4o69DK6OYutx3fft7q77iXt5IzDWfYymXOIe8CXiz/Q5c3r5PKFe7ssSsPkry9oJK9j9c7cjTNesWaPly5fXc+fOZUrAr732mvbq1UtVVTds2KAOh0NXrVqle/bs0bCwMD169KieP39eCxVqnCEBd1Fop/AvDQtTXbt2rYaFqcI6d/J9SaGsQqIWL/6anj9/XgcPHqwvvviiJiYmqohoVFSUTp8+XYODg/W+++7TpKQkrVChgrZq1Uofe+wxLV68uL766qu6efNmbdiwoR46dEj/+c9/ardu3bRnz54aHBysTZo00SeeeEKDgoL0q6++0qZNm2qZMmX0jjvu0P79+2vDhg31ww8/1GnTpmloaKhWrVpVS5UqpaVKldKZM2eqas4jW+VUnpuRrDIud+/eXe+9915NTU3VTZs2aeXKlVVV9aOPPtJWrVppamqq7t+/X4sVK6YfffSRrlu3Tp1OZ46/4/QErKp65MgR93k/pVBT4bBCnMLtGhammWIsU6aMZ0S07OIGfgPG6x+JJMGdMGsAX+B61AZgItDN/V6B+zSP/x+3l+tll6CNuY5k7YSVsbx27dpER0dfMNfvo48+SnJyMlFRUbz66qvExsYCULZsWZ5++mnq16/P7bffTqNGETgkxL3VOFxPfPyX8+cjmDx5MlWq9EfkQVwNhMlAMiKNadhwP6rK999/z4svvkj58uVRVRISEnjhhReIiIjgwIEDNG7cmP379/PDDz/w7bff8re//Y3w8HAmTpzIihUrqFChAu+88w6rVq1iz549nvg7dOjA2bNneeqpp1iyZAk1atSgePHiAMyYMYO3336bZ555htTUVLp27cqBAwcoXrw4n3/+OeAa2Sq9A9SDDz7I4sWLL1qe3gnrrbfeIjU1dwNA3XXXXfj5+REREcHBgwcBWLx4MR07dsTPz4+//e1vNGvWLFf7ymjcuHGoRiPSANdTRFuBSojsoGrVf/DNN99QpEgRwHV7oWvXrrz//vuXNVEEcBuux35WiUi8ezn9PmsqrnumxgusF7Qx15F9jgqZpiNMzlgOfPHFF5516fccAwMDL0jK6e6//3769OlDSkoKTW6Kpa8W40sS2EUFSjKQYvwfb7cfSqOJXQGYPPkwAwbEkJo6gpCQOCZNGk/Xrq4pAitWrMiSJUvw9/cnPDycH3/8kTlz5vD777/z3HPPAfDEE09w4403MnDgQHr06IGI0Lt3b1auXMmyZcsuiK9p06YUKlSIlJQUDh8+TExMDN9//71nSsKKFSvyzTffeJafffZZAN544w3efPPNbD9zhuEWsy2fPHkyK1as4KuvvsLpdOY4LWJGGUfacrccPT+zuummm9i1axcnTpwgJCQk2zoAP/74I/Pnz+eXX5bx6adB9OrVlLNnzxAWVpxnnllHsWLfMmHCBD788EPeeecdvvrqKxYuXMjnn3/OCy+8wKZNmy4Zd/pHx/Ws75Bs1p1RG4bSa6wFbMx1JKHPSE4SlKksfTrCKzFixAicTie1atWi2q5tvMkCEqhIGg4O8ADFOMjCyY956rdufYpy5WDaNOjWDbq68jJJSUmUKlUKf39/FixY4Omc1LhxYz799FNOnz7NiRMnMv2BkK5atWokJiZ6EvD58+cvmTwyjiyVncWLF1O5cmXANR9u+h8gM2bMoFGjRhctv9RIVrnVqFEjZs+eTVpaGgcPHuTHH38EICgoiF69evHYY49x7tw5wDWm9/vvv59p+6SkJIoXL05QUBB1624GlrNgAcTFHaZjxzTuueceXnjhBdasWUNaWhq7d++mWbNmvPrqq56xo3Ppe+BeESkFICI3iEjYZX1Yc0WsBWzMdaTRxK4sBsKnDOXG1F3sc1Qgoc9ITwv1co0ePdrzPk38Mo3pJ7h62vxLj1KxYkVKlixJcHAwr7zyCqdPn860n65du3LnnXcSExOD0+n0TLNXp04dOnXqhNPpJCwsjFtuuYWsChYsyMcff8xjjz1GUlISKSkp/Otf/6JmzZoX1E3XrFkzXn75ZZxOp2eIzFmzZrF48WLS0tIoV66cZ77jcePG8dBDDzFq1ChKlizJtGnTLlr+5JNPsnXrVlSV2267jejoaCpUqHDB8S7lnnvu4fvvv6dWrVpUrVqV+vXreyaaePHFFxk2bBgREREEBAQQHBzM888/n2n7li1bMnnyZKKioqhWrRoN3A/+7t27l549e3qG73zppZdITU3lgQceICkpCVXXs82unuuXpqo/i8gwYJ6I+AHngf7Azotvaa6W5HSZJL+KiYnRuLg4X4dhzJ/OngLhmS5ve8odYZRLSbj2Af0JJCcnU7hwYY4cOUJsbCxLlizhb3/7m09iEZHVqponkxWYvOHVS9Ai0tI9C8Y2ERmczfquIrLe/VqaYQBwY8w1lteXtw20bdsWp9PJLbfcwjPPPOOz5GvyJ69dgnbPADEB18wVe3D1sPtcM88i8RuusUV/F5FWwBRck0EbY66xvL68bfDc9zUmO968BxwLbFPVHQAiMhNoj2s8TgBUNePcW8uBcl6MxxhzCY0mdgV3wi2H/YM0xpu8eQm6LK4H19LtcZflpBfwdXYrRKSPiMSJSFxiYmIehmiMMcb4hjcTcHYP22Xb40tEmuFKwIOyW6+qU1Q1RlVjSpYsmYchGmOMMb7hzUvQe8g8qHU5YF/WSiISBUwFWqnqES/GY4wxxuQb3mwBrwKqiEhFESkIdAY+z1hBRCrgGgj7QVX91YuxGGOMMfmK11rAqpoiIgOAb3FNqPyOqm4Skb7u9ZOBZ4ESwET3MHAp9pyaMcaYv4LrbiAOEUnkykdoCcU132N+kx/jsphyJz/GBPkzLosp97wRV5iqWieafOS6S8BXQ0Ti8mMLOz/GZTHlTn6MCfJnXBZT7uXXuEzesskYjDHGGB+wBGyMMcb4wF8tAU/xdQA5yI9xWUy5kx9jgvwZl8WUe/k1LpOH/lL3gI0xxpj84q/WAjbGGGPyBUvAxhhjjA9c1wk4F/MNi4iMc69fLyJ1LrWtiNwgIt+JyFb3z+LXIiYRKS8iC0TkFxHZJCL/zLDNCBHZKyLx7lfraxGTe12CiGxwHzcuQ7mvzlO1DOchXkSOi8i/3Ouu6jzlMq7qIrJMRM6KyMDcbHsNzlW2Mfn4O3Wx8+SV79TVxOXN71UuYspxXnRvfadMPqGq1+UL1+ha24FKQEFgHRCRpU5rXDMsCdAAWHGpbYFXgcHu94OBV65RTGWAOu73IcCvGWIaAQy81ufJvS4BCM1mvz45T9ns5wCuAQau6jxdRlylgHrAyIzH8vF3KqeYfPmdyjYmb32n8iIub3yvchnTzUBx9/tWePn/KXvln9f13AL2zDesqueA9PmGM2oPvKcuy4FiIlLmEtu2B951v38XuOtaxKSq+1V1DYCqngB+4eLTN3o9pkvs1yfnKUud24DtqnqlI6NddlyqekhVVwHnL2Nbr56rnGLy5XfqIufpYq7mPOVlXHn5vcpNTEtV9Xf3YsZ50b31nTL5xPWcgHMz33BOdS62bWlV3Q+u/8Bw/cV8LWLyEJFwoDawIkPxAPclqncu83LT1cakwDwRWS0ifTLU8fl5wjXBx/+ylF3pecrtMa9kW2+fq0vywXfqYrzxncqLuNLl5ffqauZF99Z3yuQT13MCzs18wznVyfVcxZfpamJyrRQpDMwG/qWqx93Fk4DKgBPYD7x2DWP6u6rWwXVprL+INL6MY3srJsQ1w1Y74KMM66/mPOU2Lm9s69X9+ug7dTHe+E5B3pyrvP5eXc286N76Tpl84npOwLmZbzinOhfb9mD6pU73z0PXKCZExB/Xf5QzVPWT9AqqelBVU1U1DXgL16WpaxKTqqb/PAR8muHYPjtPbq2ANap6ML3gKs9TbuO6km29fa5y5MPvVI689J266rjc8vp7dbnzorfXP+ZF99Z3yuQT13MCvuR8w+7lbuLSAEhyX6652LafA93d77sDn12LmEREgLeBX1T19YwbZLn3eTew8RrFFCwiIe4YgoHmGY7tk/OUYX0XslwmvMrzlNu4rmRbb5+rbPn4O5VTTN76Tl1VXBnk9ffqauZF99Z3yuQX3uzh5e0Xrp6yv+LqKTjUXdYX6Ot+L8AE9/oNQMzFtnWXlwC+B7a6f95wLWICGuG6vLQeiHe/WrvX/ddddz2uf3hlrlFMlXD1vFwHbMoP58m9Lgg4AhTNss+rOk+5jOtvuFomx4Fj7vdFfPydyjYmH3+ncorJa9+pPPj9eeV7lYuYpgK/Z/gdxV1s27w6V/by/cuGojTGGGN84Hq+BG2MMcZctywBG2OMMT5gCdgYY4zxAUvAxhhjjA9YAjbGGGN8wBKwMbkkIqmSecaccBFpKiJJIrJWXLMODXfXzVi+WURG+zp+Y0z+UsDXARhzHTmtqs6MBe4xlhepalv3wBLxIvKle3V6eSCwVkQ+VdUl1zZkY0x+ZS1gY/KIqp4EVuMaNzhj+WlcAyzkxUxExpg/CUvAxuReYIbLz59mXSkiJXDNXbwpS3lxoAqw8NqEaYy5HtglaGNy74JL0G63iMhaIA14WVU3iUhTd/l6oJq7/MA1i9QYk+9ZAjbm6i1S1bY5lYtIVWCx+x5w/DWOzRiTT9klaGO8TF0z3LzEH/O8GmOMJWBjrpHJQGMRqejrQIwx+YPNhmSMMcb4gLWAjTHGGB+wBGyMMcb4gCVgY4wxxgcsARtjjDE+YAnYGGOM8QFLwMYYY4wPWAI2xhhjfOD/AWUdcWy2xwf2AAAAAElFTkSuQmCC",
       "text/plain": [
        "<Figure size 432x288 with 1 Axes>"
       ]
@@ -1282,34 +1470,22 @@
     }
    ],
    "source": [
-    "def pareto_frontier(models):\n",
+    "def pareto_frontier(models, hof):\n",
     "    for model in models:\n",
-    "        fnr, fpr = models[model]\n",
-    "#         plt.scatter(pop_1, pop_2, color='b')\n",
-    "#         plt.scatter(fitness_1, fitness_2, color='r')\n",
-    "        plt.scatter(fnr, fpr, color='b')\n",
-    "        plt.annotate(str(model), (fnr, fpr))\n",
-    "        # plt.plot(fnr, fpr, color='r', drawstyle='steps-post')\n",
-    "        plt.xlabel(\"FNR\")\n",
-    "        plt.ylabel(\"FPR\")\n",
-    "        plt.title(\"Pareto Front\")\n",
+    "        fpr, fnr = models[model]\n",
+    "        plt.scatter(fpr, fnr, color='b')\n",
+    "        if model in hof:\n",
+    "            best_fpr, best_fnr = hof[model]\n",
+    "            plt.scatter(best_fpr, best_fnr, color='r')\n",
+    "            plt.plot(best_fpr, best_fnr, color='r', drawstyle='steps-post')\n",
+    "\n",
+    "        plt.annotate(str(model), (fpr, fnr))\n",
+    "    plt.xlabel(\"FPR\")\n",
+    "    plt.ylabel(\"FNR\")\n",
+    "    plt.title(\"Pareto Front\")\n",
     "    plt.show()\n",
-    "pareto_frontier(models)"
+    "pareto_frontier(models, hof)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Pujish added a good start to K fold cross validation

The current eval function generates train and test splits that we can evaluate the accuracy with

<img width="878" alt="Screen Shot 2022-09-20 at 9 58 12 PM" src="https://user-images.githubusercontent.com/65079595/191397110-58a88093-4be0-46af-be95-e483f25ad21c.png">

One thing we still need to do is remove the initial train test split that happens in the first block of code

We also need to utilize the confusion_matrix_scorer function that I provided above the eval function

<img width="996" alt="Screen Shot 2022-09-20 at 9 59 16 PM" src="https://user-images.githubusercontent.com/65079595/191397230-4c564014-ab77-4823-95b0-b0157f205904.png">

This will give a more robust description from the cross_validate score that describes the fpr and fnr, we can average all of these and store them in our model dict

I also created a Pareto Front HOF function

<img width="493" alt="Screen Shot 2022-09-20 at 10 00 31 PM" src="https://user-images.githubusercontent.com/65079595/191397355-960508ed-7df5-4421-a38b-59d94b09a286.png">

So that now the pareto front graph looks like this:

<img width="601" alt="Screen Shot 2022-09-20 at 10 00 50 PM" src="https://user-images.githubusercontent.com/65079595/191397397-f23300e0-2e9d-4fcf-ab06-1f51d6f08da8.png">

I could not figure out how to connect the dots (the problem is that I am looking through), if we created an array of all the x, y values it would work (but we would loose the ability to annotate the models)

